### PR TITLE
[Feat/#14] 내 리뷰 목록 조회 API 간 리뷰 상세 DTO 형식 통일

### DIFF
--- a/src/main/java/com/appcenter/BJJ/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/controller/ReviewController.java
@@ -1,6 +1,7 @@
 package com.appcenter.BJJ.domain.review.controller;
 
-import com.appcenter.BJJ.domain.review.dto.MyReviewRes;
+import com.appcenter.BJJ.domain.review.dto.MyReviewsGroupedRes;
+import com.appcenter.BJJ.domain.review.dto.MyReviewsPagedRes;
 import com.appcenter.BJJ.domain.review.dto.ReviewReq.ReviewPost;
 import com.appcenter.BJJ.domain.menu.service.MenuPairService;
 import com.appcenter.BJJ.domain.review.dto.ReviewRes;
@@ -70,10 +71,10 @@ public class ReviewController {
                      - 각 식당별 최대 3개씩 리뷰 조회\s
                      - responseDTO : MyReviewRes""")
     @GetMapping("/my")
-    public ResponseEntity<MyReviewRes> getMyReviews(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<MyReviewsGroupedRes> getMyReviews(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         log.info("[로그] GET /api/reviews/my, memberNickname: {}", userDetails.getNickname());
 
-        MyReviewRes myReviewRes = reviewService.findMyReviews(userDetails.getMember().getId());
+        MyReviewsGroupedRes myReviewRes = reviewService.findMyReviews(userDetails.getMember().getId());
 
         return ResponseEntity.ok(myReviewRes);
     }
@@ -86,12 +87,12 @@ public class ReviewController {
                     - 마지막 페이지 여부 알려줌 (lastPage)\s
                     - responseDTO : ReviewRes""")
     @GetMapping("/my/cafeteria")
-    public ResponseEntity<ReviewRes> getMyReviewsByCafeteria(String cafeteriaName, int pageNumber, int pageSize, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<MyReviewsPagedRes> getMyReviewsByCafeteria(String cafeteriaName, int pageNumber, int pageSize, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         log.info("[로그] GET /api/reviews/my/cafeteria?cafeteriaName={}, memberNickname: {}", cafeteriaName, userDetails.getNickname());
 
-        ReviewRes ReviewRes = reviewService.findMyReviewsByCafeteria(userDetails.getMember().getId(), cafeteriaName, pageNumber, pageSize);
+        MyReviewsPagedRes myReviewsPagedRes = reviewService.findMyReviewsByCafeteria(userDetails.getMember().getId(), cafeteriaName, pageNumber, pageSize);
 
-        return ResponseEntity.ok(ReviewRes);
+        return ResponseEntity.ok(myReviewsPagedRes);
     }
 
     @Operation(summary = "리뷰 삭제", description = "작성한 리뷰 삭제시 noContent")

--- a/src/main/java/com/appcenter/BJJ/domain/review/dto/MyReviewsGroupedRes.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/dto/MyReviewsGroupedRes.java
@@ -12,8 +12,8 @@ import java.util.Map;
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class MyReviewRes {
+public class MyReviewsGroupedRes {
 
-    @Schema(description = "리뷰 상세정보")
+    @Schema(description = "식당 별 내 리뷰 상세정보")
     private final Map<String, List<MyReviewDetailRes>> myReviewDetailList;
 }

--- a/src/main/java/com/appcenter/BJJ/domain/review/dto/MyReviewsPagedRes.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/dto/MyReviewsPagedRes.java
@@ -1,0 +1,19 @@
+package com.appcenter.BJJ.domain.review.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MyReviewsPagedRes {
+    @Schema(description = "내 리뷰 상세정보")
+    private final List<MyReviewDetailRes> myReviewDetailList;
+    @Schema(description = "리뷰 마지막 페이지 여부", example = "true")
+    private final boolean isLastPage;
+}

--- a/src/main/java/com/appcenter/BJJ/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/repository/ReviewRepositoryCustom.java
@@ -13,5 +13,5 @@ public interface ReviewRepositoryCustom {
     List<ReviewDetailRes> findReviewsWithImagesAndMemberDetails(Long memberId, Long mainMenuId, Long subMenuId, int pageNumber, int pageSize, Sort sort, Boolean isWithImages);
     Map<String, List<MyReviewDetailRes>> findMyReviewsWithImagesAndMemberDetailsAndCafeteria(Long memberId);
     Long countMyReviewsWithImagesAndMemberDetailsByCafeteria(Long memberId, String cafeteriaName);
-    List<ReviewDetailRes> findMyReviewsWithImagesAndMemberDetailsByCafeteria(Long memberId, String cafeteriaName, int pageNumber, int pageSize);
+    List<MyReviewDetailRes> findMyReviewsWithImagesAndMemberDetailsByCafeteria(Long memberId, String cafeteriaName, int pageNumber, int pageSize);
 }

--- a/src/main/java/com/appcenter/BJJ/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/repository/ReviewRepositoryImpl.java
@@ -265,10 +265,10 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom{
     }
 
     @Override
-    public List<ReviewDetailRes> findMyReviewsWithImagesAndMemberDetailsByCafeteria(Long memberId, String cafeteriaName, int pageNumber, int pageSize) {
+    public List<MyReviewDetailRes> findMyReviewsWithImagesAndMemberDetailsByCafeteria(Long memberId, String cafeteriaName, int pageNumber, int pageSize) {
 
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
-        CriteriaQuery<ReviewDetailRes> query = cb.createQuery(ReviewDetailRes.class);
+        CriteriaQuery<MyReviewDetailRes> query = cb.createQuery(MyReviewDetailRes.class);
         Root<Review> review = query.from(Review.class);
 
         // 조건문 리스트
@@ -301,12 +301,11 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom{
 
         // 쿼리에서 선택할 내용 설정
         query.select(cb.construct(
-                ReviewDetailRes.class,
+                MyReviewDetailRes.class,
                 review.get("id"),
                 review.get("comment"),
                 review.get("rating"),
                 review.get("likeCount"),
-                cb.literal(false),
                 review.get("createdDate"),
                 menuPair.get("id"),
                 mainMenu.get("menuName"),
@@ -318,7 +317,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom{
         query.orderBy(cb.desc(review.get("id")));
 
         // 페이징 처리
-        TypedQuery<ReviewDetailRes> typedQuery = entityManager.createQuery(query);
+        TypedQuery<MyReviewDetailRes> typedQuery = entityManager.createQuery(query);
         typedQuery.setFirstResult(pageNumber);
         typedQuery.setMaxResults(pageSize);
 


### PR DESCRIPTION
### 🔅 이슈번호
close #14 

---

### ⏰ 작업한 내용
1. 기존 GET /api/reviews/my (회원이 작성한 리뷰 조회)의 응답 DTO의 이름을 MyReviewRes에서 MyReviewsGroupedRes로 변경
2. GET /api/reviews/my/cafeteria (특정 식당에 회원이 작성한 리뷰 조회)의 응답 DTO를 ReviewRes 대신 MyReviewsPagedRes를 생성해서 변경

---

### ⌛️ 스크린샷 (Optional)
1
![image](https://github.com/user-attachments/assets/391a65f9-96df-48a9-8283-12b6b4e562fc)
2
![image](https://github.com/user-attachments/assets/0d62cc7c-33f6-4757-9c6f-50429940b23e)
