### PR TITLE
[Feat/#29] 리뷰 이미지 모아보기 기능 추가

### DIFF
--- a/src/main/java/com/appcenter/BJJ/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/controller/ReviewController.java
@@ -4,6 +4,7 @@ import com.appcenter.BJJ.domain.menu.service.MenuPairService;
 import com.appcenter.BJJ.domain.review.domain.Sort;
 import com.appcenter.BJJ.domain.review.dto.MyReviewsGroupedRes;
 import com.appcenter.BJJ.domain.review.dto.MyReviewsPagedRes;
+import com.appcenter.BJJ.domain.review.dto.ReviewImageRes;
 import com.appcenter.BJJ.domain.review.dto.ReviewReq.ReviewPost;
 import com.appcenter.BJJ.domain.review.dto.ReviewRes;
 import com.appcenter.BJJ.domain.review.service.ReviewLikeService;
@@ -120,5 +121,15 @@ public class ReviewController {
         boolean isLiked = reviewLikeService.toggleReviewLike(reviewId, userDetails.getMember().getId());
 
         return ResponseEntity.ok(isLiked);
+    }
+
+    @Operation(summary= "리뷰 이미지 조회", description = "메뉴쌍에 대한 리뷰 id와 리뷰 이미지 경로 목록 반환")
+    @GetMapping("images")
+    public ResponseEntity<ReviewImageRes> getImages(Long menuPairId, int pageNumber, int pageSize) {
+        log.info("[로그] GET /api/reviews/images?menuPairId={}&pageNumber={}&pageSize={}", menuPairId, pageNumber, pageSize);
+
+        ReviewImageRes reviewImageRes = reviewService.findReviewImagesByMenuPairId(menuPairId, pageNumber, pageSize);
+
+        return ResponseEntity.ok(reviewImageRes);
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/review/dto/ReviewImageDetailRes.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/dto/ReviewImageDetailRes.java
@@ -1,0 +1,16 @@
+package com.appcenter.BJJ.domain.review.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewImageDetailRes {
+
+    @Schema(description = "리뷰 id", example = "1")
+    private final Long reviewId;
+    @Schema(description = "리뷰 이미지 이름", example = "23fsddfesff=3vlsdd-3sdf56.png")
+    private final String imageName;
+}

--- a/src/main/java/com/appcenter/BJJ/domain/review/dto/ReviewImageRes.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/dto/ReviewImageRes.java
@@ -1,0 +1,20 @@
+package com.appcenter.BJJ.domain.review.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewImageRes {
+
+    @Schema(description = "리뷰 이미지 상세정보")
+    private final List<ReviewImageDetailRes> reviewImageDetailList;
+    @Schema(description = "리뷰 이미지 마지막 페이지 여부", example = "true")
+    private final boolean isLastPage;
+}

--- a/src/main/java/com/appcenter/BJJ/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/repository/ReviewRepository.java
@@ -1,8 +1,9 @@
 package com.appcenter.BJJ.domain.review.repository;
 
 import com.appcenter.BJJ.domain.review.domain.Review;
-import org.springframework.data.domain.Page;
+import com.appcenter.BJJ.domain.review.dto.ReviewImageDetailRes;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -12,4 +13,16 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
     Float findAverageRatingByMenuPairId(Long menuPairId);
 
     int countByMenuPair_Id(Long menuPairId);
+
+    @Query("""
+        SELECT new com.appcenter.BJJ.domain.review.dto.ReviewImageDetailRes(
+            i.review.id,
+            i.name
+        )
+        FROM Image i
+        WHERE i.review.menuPair.mainMenuId = :mainMenuId OR i.review.menuPair.mainMenuId = :subMenuId
+            OR i.review.menuPair.subMenuId = :mainMenuId OR i.review.menuPair.subMenuId = :subMenuId
+        ORDER BY i.id DESC
+    """)
+    Slice<ReviewImageDetailRes> findReviewImagesByMenuPairId(Long mainMenuId, Long subMenuId, Pageable pageable);
 }

--- a/src/main/java/com/appcenter/BJJ/domain/review/service/ReviewService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/service/ReviewService.java
@@ -12,6 +12,8 @@ import com.appcenter.BJJ.domain.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -174,5 +176,19 @@ public class ReviewService {
         }
 
         return menuPairId;
+    }
+
+    public ReviewImageRes findReviewImagesByMenuPairId(Long menuPairId, int pageNumber, int pageSize) {
+        log.info("[로그] findReviewImagesByMenuPairId(), menuPairId : {}, pageNumber : {}, pageSize: {}", menuPairId, pageNumber, pageSize);
+
+        MenuPair menuPair = menuPairRepository.findById(menuPairId)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 메뉴쌍이 존재하지 않습니다."));
+
+        Slice<ReviewImageDetailRes> reviewImageDetailResSlice = reviewRepository.findReviewImagesByMenuPairId(menuPair.getMainMenuId(), menuPair.getSubMenuId(), PageRequest.of(pageNumber, pageSize));
+
+        return ReviewImageRes.builder()
+                .reviewImageDetailList(reviewImageDetailResSlice.getContent())
+                .isLastPage(reviewImageDetailResSlice.isLast())
+                .build();
     }
 }


### PR DESCRIPTION
### 🔅 이슈번호
close #29 

---

### ⏰ 작업한 내용
- 메뉴 상세 페이지에 필요한 리뷰 이미지 모아보기 기능으로 리뷰 이미지 조회 API를 추가하였다.
GET /api/reviews/images

---

### ⌛️ 스크린샷 (Optional)

![image](https://github.com/user-attachments/assets/f0cc71da-b020-4d95-98d1-3f1dbea01665)
<i>스웨거 입력 값 예시</i>

![image](https://github.com/user-attachments/assets/990881e2-8d55-49f8-9efe-646167addb19)
<i>스웨거 결과 값 예시</i>

