### PR TITLE
[Chore/#34] 하나의 도커 볼륨이 여러 폴더에 마운트 된 형태 수정

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -55,7 +55,5 @@ jobs:
           key: ${{ secrets.SERVER_KEY }}
           script_stop: true
           script: |
-            export STORAGE_IMAGES_REVIEW=${{ secrets.STORAGE_IMAGES_REVIEW }}
-            export STORAGE_IMAGES_CAFETERIA=${{ secrets.STORAGE_IMAGES_CAFETERIA }}
-            export STORAGE_IMAGES_ITEM=${{ secrets.STORAGE_IMAGES_ITEM }}
-              sh bjj/deploy-bjj.sh
+            export STORAGE_IMAGES=${{ secrets.STORAGE_IMAGES }}
+            sh bjj/deploy-bjj.sh


### PR DESCRIPTION
### 🔅 이슈번호
close #34 

---

### ⏰ 작업한 내용

- Github Secret에서 기존 세 폴더 경로 삭제 및 상위 폴더 경로 추가
- 서버의 배포용 쉘파일에서 세 폴더 대신 상위 폴더로 볼륨을 마운트 하도록 변경 및 폴더 경로를 환경 변수에 추가하지 않도록 변경
- application.properties에서 환경 변수로 입력 받는 경로를 직접 입력하는 값으로 수정

---

### ⌛️ 스크린샷 (Optional)
