### PR TITLE
[Feat/#30] 메뉴 랭킹 기능 추가

### DIFF
--- a/src/main/java/com/appcenter/BJJ/domain/image/ImageDto.java
+++ b/src/main/java/com/appcenter/BJJ/domain/image/ImageDto.java
@@ -1,0 +1,6 @@
+package com.appcenter.BJJ.domain.image;
+
+public interface ImageDto {
+    Long getMenuId();
+    String getImageName();
+}

--- a/src/main/java/com/appcenter/BJJ/domain/image/ImageRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/image/ImageRepository.java
@@ -31,4 +31,7 @@ public interface ImageRepository extends JpaRepository<Image, Long>, ImageReposi
          WHERE row_num = 1
     """, nativeQuery = true)
     List<ImageDto> findFirstImagesOfMostLikedReviewInMainMenuIds(List<Long> mainMenuIds);
+
+    @Query("SELECT i FROM Image i JOIN FETCH i.review r WHERE i.review.id = :reviewId")
+    List<Image> findByReviewId(Long reviewId);
 }

--- a/src/main/java/com/appcenter/BJJ/domain/image/ImageRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/image/ImageRepository.java
@@ -9,4 +9,26 @@ public interface ImageRepository extends JpaRepository<Image, Long>, ImageReposi
 
     @Query("SELECT i FROM Image i JOIN FETCH i.review r WHERE i.review.id IN :reviewIdList")
     List<Image> findByReviewIdList(List<Long> reviewIdList);
+
+    @Query(value = """
+        WITH numberedImage AS (
+             SELECT
+                 mp.main_menu_id as menuId,
+                 i.name as imageName,
+                 ROW_NUMBER() OVER (
+                     PARTITION BY mp.main_menu_id
+                     ORDER BY r.like_count DESC, r.id DESC, i.id
+                     ) AS row_num
+         FROM review_tb r
+             LEFT JOIN image_tb i ON r.id = i.review_id
+             JOIN menu_pair_tb mp ON r.menu_pair_id = mp.id
+         WHERE mp.main_menu_id IN :mainMenuIds
+             )
+         SELECT
+             menuId,
+             imageName
+         FROM numberedImage
+         WHERE row_num = 1
+    """, nativeQuery = true)
+    List<ImageDto> findFirstImagesOfMostLikedReviewInMainMenuIds(List<Long> mainMenuIds);
 }

--- a/src/main/java/com/appcenter/BJJ/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/appcenter/BJJ/domain/menu/controller/MenuController.java
@@ -1,7 +1,9 @@
 package com.appcenter.BJJ.domain.menu.controller;
 
+import com.appcenter.BJJ.domain.menu.dto.MenuRankingPagedRes;
 import com.appcenter.BJJ.domain.menu.dto.MenuRes;
 import com.appcenter.BJJ.domain.menu.service.MenuLikeService;
+import com.appcenter.BJJ.domain.menu.service.MenuRankingService;
 import com.appcenter.BJJ.global.jwt.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,6 +23,7 @@ import java.util.List;
 public class MenuController {
 
     private final MenuLikeService menuLikeService;
+    private final MenuRankingService menuRankingService;
 
     @PostMapping("/{menuId}/like")
     @Operation(summary = "메뉴 좋아요 토글", description = "좋아요 추가 시 true, 좋아요 취소 시 false 반환")
@@ -40,5 +43,22 @@ public class MenuController {
         List<MenuRes> likedMenuList = menuLikeService.getLikedMenus(userDetails.getMember().getId());
 
         return ResponseEntity.ok(likedMenuList);
+    }
+
+    @GetMapping("/ranking")
+    @Operation(summary = "이번 학기 메뉴 랭킹 조회",
+            description = """
+                    - 이번 학기의 메뉴 랭킹 목록을 불러옴\s
+                    - pageSize만큼 메뉴 랭킹 조회\s
+                    - pageNumber는 0부터 시작 (0..9 -> 10->19 -> 20..29)\s
+                    - 마지막 페이지 여부 알려줌 (lastPage)\s
+                    - responseDTO : MenuRankingRes
+                    """)
+    public ResponseEntity<MenuRankingPagedRes> getRanking(int pageNumber, int pageSize) {
+        log.info("[로그] GET /api/menus/ranking?pageNumber={}&pageSize={}", pageNumber, pageSize);
+
+        MenuRankingPagedRes menuRankingPagedRes = menuRankingService.getMenuRanking(pageNumber, pageSize);
+
+        return ResponseEntity.ok(menuRankingPagedRes);
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/menu/domain/MenuRanking.java
+++ b/src/main/java/com/appcenter/BJJ/domain/menu/domain/MenuRanking.java
@@ -1,0 +1,37 @@
+package com.appcenter.BJJ.domain.menu.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@ToString
+@Table(name = "menu_ranking_tb")
+@NoArgsConstructor
+public class MenuRanking {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long menuId;
+    private String menuName;
+    private Float menuRating;
+    private Long ratingCount;
+    private String cafeteriaName;
+    private String cafeteriaCorner;
+    private Integer semester;
+    private LocalDateTime updatedAt;
+
+    public void updateMenuRanking(Long menuId, String menuName, Float menuRating, String cafeteriaName, String cafeteriaCorner, Integer semester, Long ratingCount, LocalDateTime updatedAt) {
+        this.menuId = menuId;
+        this.menuName = menuName;
+        this.menuRating = menuRating;
+        this.cafeteriaName = cafeteriaName;
+        this.cafeteriaCorner = cafeteriaCorner;
+        this.semester = semester;
+        this.ratingCount = ratingCount;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/domain/menu/dto/MenuInfoDto.java
+++ b/src/main/java/com/appcenter/BJJ/domain/menu/dto/MenuInfoDto.java
@@ -1,0 +1,14 @@
+package com.appcenter.BJJ.domain.menu.dto;
+
+import lombok.*;
+
+@Getter
+@ToString
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MenuInfoDto {
+    private final Long menuId;
+    private final String menuName;
+    private final String cafeteriaName;
+    private final String cafeteriaCorner;
+
+}

--- a/src/main/java/com/appcenter/BJJ/domain/menu/dto/MenuLikeCountDto.java
+++ b/src/main/java/com/appcenter/BJJ/domain/menu/dto/MenuLikeCountDto.java
@@ -1,0 +1,14 @@
+package com.appcenter.BJJ.domain.menu.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MenuLikeCountDto {
+    private final Long menuId;
+    private final Long menuLikeCount;
+}

--- a/src/main/java/com/appcenter/BJJ/domain/menu/dto/MenuRankingDetailRes.java
+++ b/src/main/java/com/appcenter/BJJ/domain/menu/dto/MenuRankingDetailRes.java
@@ -1,0 +1,45 @@
+package com.appcenter.BJJ.domain.menu.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+public class MenuRankingDetailRes {
+
+    @Schema(description = "메뉴 id", example = "1")
+    private final Long menuId;
+    @Schema(description = "메뉴 이름", example = "등심돈까스")
+    private final String menuName;
+    @Schema(description = "메뉴 평점", example = "4.5")
+    private final Float menuRating;
+    @Schema(description = "식당 이름", example = "학생식당")
+    private final String cafeteriaName;
+    @Schema(description = "식당 코너", example = "중식(백반)")
+    private final String cafeteriaCorner;
+    @Schema(description = "베스트 리뷰 id", example = "1")
+    private final Long bestReviewId;
+    @Schema(description = "리뷰 이미지 이름", example = "23fsddfesff=3vlsdd-3sdf56.png")
+    private String reviewImageName;
+    @Schema(description = "업데이트 시간", example = "2025-01-06")
+    private final LocalDate updatedAt;
+
+    @Builder
+    private MenuRankingDetailRes(Long menuId, String menuName, Float menuRating, String cafeteriaName, String cafeteriaCorner, Long bestReviewId, LocalDateTime updatedAt) {
+        this.menuId = menuId;
+        this.menuName = menuName;
+        // 클라이언트 요구사항에 따라 10점 만점으로 변경 및 소수점 첫째자리로 제한
+        this.menuRating = Math.round(menuRating * 2 * 10) / 10.0f;
+        this.cafeteriaName = cafeteriaName;
+        this.cafeteriaCorner = cafeteriaCorner;
+        this.bestReviewId = bestReviewId;
+        // 클라이언트 요구사항에 따라 업데이트 날짜를 하루 전으로 표기 및 연-월-일만 표기하도록 변환
+        this.updatedAt = updatedAt.minusDays(1).toLocalDate();
+    }
+
+    public void initReviewImageName(String reviewImageName) {
+        this.reviewImageName = reviewImageName;
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/domain/menu/dto/MenuRankingPagedRes.java
+++ b/src/main/java/com/appcenter/BJJ/domain/menu/dto/MenuRankingPagedRes.java
@@ -1,0 +1,16 @@
+package com.appcenter.BJJ.domain.menu.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MenuRankingPagedRes {
+    @Schema(description = "메뉴 랭킹 상세정보")
+    private final List<MenuRankingDetailRes> menuRankingDetailList;
+    @Schema(description = "메뉴 랭킹 마지막 페이지 여부", example = "true")
+    private final boolean isLastPage;
+}

--- a/src/main/java/com/appcenter/BJJ/domain/menu/dto/MenuRatingStatsDto.java
+++ b/src/main/java/com/appcenter/BJJ/domain/menu/dto/MenuRatingStatsDto.java
@@ -1,0 +1,12 @@
+package com.appcenter.BJJ.domain.menu.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@ToString
+public class MenuRatingStatsDto {
+    private final Long menuId;
+    private final Long ratingSum;
+    private final Long ratingCount;
+}

--- a/src/main/java/com/appcenter/BJJ/domain/menu/repository/MenuLikeRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/menu/repository/MenuLikeRepository.java
@@ -2,6 +2,7 @@ package com.appcenter.BJJ.domain.menu.repository;
 
 import com.appcenter.BJJ.domain.menu.domain.Menu;
 import com.appcenter.BJJ.domain.menu.domain.MenuLike;
+import com.appcenter.BJJ.domain.menu.dto.MenuLikeCountDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -14,4 +15,16 @@ public interface MenuLikeRepository extends JpaRepository<MenuLike, Long> {
 
     @Query("SELECT m FROM Menu m JOIN MenuLike ml ON m.id = ml.menuId WHERE ml.memberId = :memberId")
     List<Menu> findLikedMenusByMemberId(long memberId);
+
+    @Query("""
+        SELECT new com.appcenter.BJJ.domain.menu.dto.MenuLikeCountDto(
+            m.id,
+            CAST(COALESCE(COUNT(ml), 0) AS Long)
+        )
+        FROM MenuLike ml
+        RIGHT JOIN Menu m ON ml.menuId = m.id
+        WHERE m.id IN :menuIds
+        GROUP BY m.id
+    """)
+    List<MenuLikeCountDto> countGroupByMenuIds(List<Long> menuIds);
 }

--- a/src/main/java/com/appcenter/BJJ/domain/menu/repository/MenuRankingRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/menu/repository/MenuRankingRepository.java
@@ -1,0 +1,12 @@
+package com.appcenter.BJJ.domain.menu.repository;
+
+import com.appcenter.BJJ.domain.menu.domain.MenuRanking;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface MenuRankingRepository extends JpaRepository<MenuRanking, Long> {
+    @Query("SELECT mr FROM MenuRanking mr WHERE mr.semester = :semester AND mr.menuId IN :menuIds")
+    List<MenuRanking> findBySemesterInMenuIds(Integer semester, List<Long> menuIds);
+}

--- a/src/main/java/com/appcenter/BJJ/domain/menu/repository/MenuRankingRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/menu/repository/MenuRankingRepository.java
@@ -1,6 +1,8 @@
 package com.appcenter.BJJ.domain.menu.repository;
 
 import com.appcenter.BJJ.domain.menu.domain.MenuRanking;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -9,4 +11,7 @@ import java.util.List;
 public interface MenuRankingRepository extends JpaRepository<MenuRanking, Long> {
     @Query("SELECT mr FROM MenuRanking mr WHERE mr.semester = :semester AND mr.menuId IN :menuIds")
     List<MenuRanking> findBySemesterInMenuIds(Integer semester, List<Long> menuIds);
+
+    @Query("SELECT mr FROM MenuRanking mr WHERE mr.semester >= :semester AND mr.ratingCount > :minRatingCount ORDER BY mr.menuRating DESC, mr.ratingCount DESC, mr.id DESC")
+    Slice<MenuRanking> findBySemesterAndRatingCountOrderByRating(Integer semester, int minRatingCount, Pageable pageable);
 }

--- a/src/main/java/com/appcenter/BJJ/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/menu/repository/MenuRepository.java
@@ -1,10 +1,26 @@
 package com.appcenter.BJJ.domain.menu.repository;
 
 import com.appcenter.BJJ.domain.menu.domain.Menu;
+import com.appcenter.BJJ.domain.menu.dto.MenuInfoDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
     Optional<Menu> findFirstByMenuNameAndCafeteriaId(String menuName, Long cafeteriaId);
+
+    @Query("""
+        SELECT new com.appcenter.BJJ.domain.menu.dto.MenuInfoDto(
+            m.id,
+            m.menuName,
+            c.name,
+            c.corner
+        )
+        FROM Menu m
+        JOIN Cafeteria c ON m.cafeteriaId = c.id
+        WHERE m.id IN :menuIds
+    """)
+    List<MenuInfoDto> findMenusWithCafeteriaInMenuIds(List<Long> menuIds);
 }

--- a/src/main/java/com/appcenter/BJJ/domain/menu/repository/TodayDietRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/menu/repository/TodayDietRepository.java
@@ -54,4 +54,12 @@ public interface TodayDietRepository extends JpaRepository<TodayDiet, Long> {
         WHERE c.name = :cafeteriaName AND td.date = CURRENT_DATE
     """)
     List<TodayMenuRes> findTodayMainMenusByCafeteriaName(String cafeteriaName);
+
+    @Query("""
+        SELECT mp.mainMenuId
+        FROM TodayDiet td
+        JOIN MenuPair mp ON td.menuPairId = mp.id
+        WHERE td.date = :date
+    """)
+    List<Long> findMainMenuIdsByDate(LocalDate date);
 }

--- a/src/main/java/com/appcenter/BJJ/domain/menu/service/MenuRankingService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/menu/service/MenuRankingService.java
@@ -1,17 +1,21 @@
 package com.appcenter.BJJ.domain.menu.service;
 
+import com.appcenter.BJJ.domain.image.ImageDto;
+import com.appcenter.BJJ.domain.image.ImageRepository;
 import com.appcenter.BJJ.domain.menu.domain.MenuRanking;
-import com.appcenter.BJJ.domain.menu.dto.MenuInfoDto;
-import com.appcenter.BJJ.domain.menu.dto.MenuLikeCountDto;
-import com.appcenter.BJJ.domain.menu.dto.MenuRatingStatsDto;
+import com.appcenter.BJJ.domain.menu.dto.*;
 import com.appcenter.BJJ.domain.menu.repository.MenuLikeRepository;
 import com.appcenter.BJJ.domain.menu.repository.MenuRankingRepository;
 import com.appcenter.BJJ.domain.menu.repository.MenuRepository;
 import com.appcenter.BJJ.domain.menu.repository.TodayDietRepository;
+import com.appcenter.BJJ.domain.review.dto.BestReviewDto;
 import com.appcenter.BJJ.domain.review.repository.ReviewRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -35,6 +40,79 @@ public class MenuRankingService {
     private final ReviewRepository reviewRepository;
     private final MenuLikeRepository menuLikeRepository;
     private final MenuRepository menuRepository;
+    private final ImageRepository imageRepository;
+
+    public MenuRankingPagedRes getMenuRanking(int pageNumber, int pageSize) {
+        log.info("[로그] getMenuRanking() 시작, pageNumber: {}, pageSize: {}", pageNumber, pageSize);
+
+        // 오늘 날짜 및 학기 구하기
+        LocalDate now = LocalDate.now();
+        int semester = getSemester(now);
+
+        // 최소 리뷰 개수를 충족한 메뉴 랭킹 리스트를 최대 maxMenuRank개 가져오기
+        int minRatingCount = 5; // 최소 리뷰 개수
+        int maxMenuRank = 30;   // 랭킹 최대 값
+        if (pageNumber * pageSize + pageSize > maxMenuRank) {
+            pageSize = maxMenuRank - pageNumber * pageSize;
+        }
+        Slice<MenuRanking> menuRankingSlice = (pageSize > 0)
+                ? menuRankingRepository.findBySemesterAndRatingCountOrderByRating(semester, minRatingCount, PageRequest.of(pageNumber, pageSize))
+                : new SliceImpl<>(Collections.emptyList());
+        log.debug("[로그] menuRankingList = {}", menuRankingSlice.getContent());
+
+        // 각 메뉴별 가장 좋아요를 많이 받은 리뷰 가져오기
+        List<Long> menuIdList = menuRankingSlice.stream()
+                .map(MenuRanking::getMenuId).toList();
+        Map<Long, BestReviewDto> bestReviewMap = reviewRepository.findMostLikedReviewIdsInMainMenuIds(menuIdList).stream()
+                .collect(Collectors.toMap(BestReviewDto::getMenuId, Function.identity()));
+        log.debug("[로그] bestReviewMap = {}", bestReviewMap);
+
+        List<MenuRankingDetailRes> menuRankingDetailList = menuRankingSlice.stream().map(menuRanking -> {
+
+            BestReviewDto bestReviewDto = bestReviewMap.get(menuRanking.getMenuId());
+            Long bestReviewId = null;
+            if (bestReviewDto == null) {
+                log.warn("[로그] menuId가 {}인 BestReviewDto가 존재하지 않습니다", menuRanking.getMenuId());
+            } else {
+                bestReviewId = bestReviewDto.getBestReviewId();
+            }
+
+            return MenuRankingDetailRes.builder()
+                    .menuId(menuRanking.getMenuId())
+                    .menuName(menuRanking.getMenuName())
+                    .menuRating(menuRanking.getMenuRating())
+                    .cafeteriaName(menuRanking.getCafeteriaName())
+                    .cafeteriaCorner(menuRanking.getCafeteriaCorner())
+                    .bestReviewId(bestReviewId)
+                    .updatedAt(menuRanking.getUpdatedAt())
+                    .build();
+        }).toList();
+
+        // 1, 2, 3등 메뉴의 가장 좋아요를 많이 받은 리뷰 이미지 가져오기
+        int startIndex = pageNumber * pageSize;
+        if (startIndex < 3) {
+            int endIndex = Math.min(3 - startIndex, menuIdList.size());
+            List<Long> bestThreeMenuIds = menuIdList.subList(0, endIndex);
+            Map<Long, ImageDto> imageMap = imageRepository.findFirstImagesOfMostLikedReviewInMainMenuIds(bestThreeMenuIds).stream()
+                    .collect(Collectors.toMap(ImageDto::getMenuId, Function.identity()));
+
+            String imageMapLog = imageMap.entrySet().stream()
+                    .map(entry -> String.format("%s=ImageDto(menuId=%d, imageName=%s)", entry.getKey(), entry.getValue().getMenuId(), entry.getValue().getImageName()))
+                    .collect(Collectors.joining(", "));
+            log.info("[로그] imageDto = {{}}", imageMapLog);
+
+            for (int i = 0; i < endIndex; i++) {
+                MenuRankingDetailRes menuRankingDetailRes = menuRankingDetailList.get(i);
+                menuRankingDetailRes.initReviewImageName(imageMap.get(menuRankingDetailRes.getMenuId()).getImageName());
+            }
+        }
+
+        return MenuRankingPagedRes.builder()
+                .menuRankingDetailList(menuRankingDetailList)
+                .isLastPage(menuRankingSlice.isLast())
+                .build();
+    }
+
 
     @PostConstruct  // bean 생성 후 실행
     @Transactional

--- a/src/main/java/com/appcenter/BJJ/domain/menu/service/MenuRankingService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/menu/service/MenuRankingService.java
@@ -1,0 +1,146 @@
+package com.appcenter.BJJ.domain.menu.service;
+
+import com.appcenter.BJJ.domain.menu.domain.MenuRanking;
+import com.appcenter.BJJ.domain.menu.dto.MenuInfoDto;
+import com.appcenter.BJJ.domain.menu.dto.MenuLikeCountDto;
+import com.appcenter.BJJ.domain.menu.dto.MenuRatingStatsDto;
+import com.appcenter.BJJ.domain.menu.repository.MenuLikeRepository;
+import com.appcenter.BJJ.domain.menu.repository.MenuRankingRepository;
+import com.appcenter.BJJ.domain.menu.repository.MenuRepository;
+import com.appcenter.BJJ.domain.menu.repository.TodayDietRepository;
+import com.appcenter.BJJ.domain.review.repository.ReviewRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MenuRankingService {
+
+    private final MenuRankingRepository menuRankingRepository;
+    private final TodayDietRepository todayDietRepository;
+    private final ReviewRepository reviewRepository;
+    private final MenuLikeRepository menuLikeRepository;
+    private final MenuRepository menuRepository;
+
+    @PostConstruct  // bean 생성 후 실행
+    @Transactional
+    @Scheduled(cron = "0 0 4 * * *") // 오전 4시마다 실행
+    protected void updateMenuRanking() {
+        log.info("[로그] updateRankings() 시작");
+
+        // 어제 날짜 및 학기 구하기
+        LocalDateTime now = LocalDateTime.now();
+        LocalDate yesterday = now.toLocalDate().minusDays(1);
+        int semester = getSemester(yesterday);
+
+        // 어제 식단의 메뉴 ID 목록 조회
+        List<Long> menuIdList = todayDietRepository.findMainMenuIdsByDate(yesterday);
+        log.info("[로그] menuIdList = {}", menuIdList);
+
+        // 메뉴 이름 및 식당 조회
+        List<MenuInfoDto> menuInfoDtos = menuRepository.findMenusWithCafeteriaInMenuIds(menuIdList);
+        log.info("[로그] menuInfoDtos = {}", menuInfoDtos);
+        // 해당 학기 메뉴 Id의 메뉴 랭킹 조회
+        Map<Long, MenuRanking> menuRankingMap = menuRankingRepository.findBySemesterInMenuIds(semester, menuIdList).stream()
+                .collect(Collectors.toMap(MenuRanking::getMenuId, Function.identity()));
+        log.info("[로그] menuRankingMap = {}", menuRankingMap);
+
+        // 특정 메뉴 평균 점수 r (Ratings)
+        // 특정 메뉴 리뷰 개수 c (count)
+        Map<Long, MenuRatingStatsDto> menuRatingStatsDtoMap = reviewRepository.calculateRatingStatsByMainMenuIds(menuIdList).stream()
+                .collect(Collectors.toMap(MenuRatingStatsDto::getMenuId, Function.identity()));
+        log.info("[로그] menuRatingStatsDtoMap = {}", menuRatingStatsDtoMap);
+        // 전체 메뉴 평균 점수 T (Total Ratings)
+        Float totalAverageRating = reviewRepository.findAverageRating();
+        log.info("[로그] totalAverageRating = {}", totalAverageRating);
+        // 신뢰할 수 있는 리뷰 개수 C (Confidence Count)
+        int confidenceCount = 10;
+        // 리뷰 점수의 최대 값 m (Maximum Rating)
+        float maximumRating = 5.0f;
+        // 특정 메뉴 좋아요 수 l (Likes)
+        Map<Long, MenuLikeCountDto> menuLikeCountMap = menuLikeRepository.countGroupByMenuIds(menuIdList).stream()
+                .collect(Collectors.toMap(MenuLikeCountDto::getMenuId, Function.identity()));
+        log.info("[로그] menuLikeCountMap = {}", menuLikeCountMap);
+
+        // 좋아요 수의 가중치 w (Weight)
+        float weight = 0.25f;   // 좋아요 4개 당 5점 리뷰 1개의 가치
+
+        // 업데이트할 MenuRanking 리스트 생성
+        List<MenuRanking> menuRankingsToUpdate = new ArrayList<>();
+
+        // 베이지안 평균 (r*c + T*C) / (c + C)
+        // 조정된 평점 = (r*c + T*C + m*l*w) / (c + C + l*w)
+        menuInfoDtos.forEach(menuInfoDto -> {
+
+            Long menuId = menuInfoDto.getMenuId();
+            String menuName = menuInfoDto.getMenuName();
+            String cafeteriaName = menuInfoDto.getCafeteriaName();
+            String cafeteriaCorner = menuInfoDto.getCafeteriaCorner();
+
+            MenuRatingStatsDto menuRatingStatsDto = menuRatingStatsDtoMap.get(menuId);
+            if (menuRatingStatsDto == null) {
+                log.warn("[로그] menuId가 {}인 MenuRatingStatsDto가 존재하지 않습니다", menuId);
+                return; // continue
+            }
+            Long ratingSum = menuRatingStatsDto.getRatingSum();
+            Long ratingCount = menuRatingStatsDto.getRatingCount();
+
+            MenuLikeCountDto menuLikeCountDto = menuLikeCountMap.get(menuId);
+            if (menuLikeCountDto == null) {
+                log.warn("[로그] menuId가 {}인 MenuLikeCountDto가 존재하지 않습니다", menuId);
+                return; // continue
+            }
+            Long likeCount = menuLikeCountDto.getMenuLikeCount();
+
+            // 조정된 평점 계산
+            float menuRating = (ratingSum + totalAverageRating * confidenceCount + maximumRating * likeCount * weight)
+                                            / (ratingCount + confidenceCount + likeCount * weight);
+
+            MenuRanking menuRanking = menuRankingMap.getOrDefault(menuId, new MenuRanking());
+            menuRanking.updateMenuRanking(
+                    menuId,
+                    menuName,
+                    menuRating,
+                    cafeteriaName,
+                    cafeteriaCorner,
+                    semester,
+                    ratingCount,
+                    now
+            );
+
+            menuRankingsToUpdate.add(menuRanking);
+        });
+
+        // TODO: Bulk Insert로 변경
+        menuRankingRepository.saveAll(menuRankingsToUpdate);
+    }
+
+    private static int getSemester(LocalDate localDate) {
+        int todayYear = localDate.getYear();
+        int todayMonth = localDate.getMonthValue();
+
+        int semester = 0;
+        if (todayMonth < 3) {
+            semester = (todayYear - 1) * 100 + 9;
+        } else if (todayMonth < 9) {
+            semester = todayYear * 100 + 3;
+        } else {
+            semester = todayYear * 100 + 9;
+        }
+        return semester;
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/controller/ReviewController.java
@@ -4,6 +4,7 @@ import com.appcenter.BJJ.domain.menu.service.MenuPairService;
 import com.appcenter.BJJ.domain.review.domain.Sort;
 import com.appcenter.BJJ.domain.review.dto.MyReviewsGroupedRes;
 import com.appcenter.BJJ.domain.review.dto.MyReviewsPagedRes;
+import com.appcenter.BJJ.domain.review.dto.ReviewDetailRes;
 import com.appcenter.BJJ.domain.review.dto.ReviewReq.ReviewPost;
 import com.appcenter.BJJ.domain.review.dto.ReviewRes;
 import com.appcenter.BJJ.domain.review.service.ReviewLikeService;
@@ -120,5 +121,15 @@ public class ReviewController {
         boolean isLiked = reviewLikeService.toggleReviewLike(reviewId, userDetails.getMember().getId());
 
         return ResponseEntity.ok(isLiked);
+    }
+
+    @Operation(summary = "리뷰 상세 조회")
+    @GetMapping("{reviewId}")
+    public ResponseEntity<ReviewDetailRes> getReviewDetail(@PathVariable long reviewId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        log.info("[로그] GET /api/reviews/{}, memberNickname: {}", reviewId, userDetails.getNickname());
+
+        ReviewDetailRes reviewDetailRes = reviewService.findReviewWithDetail(reviewId, userDetails.getMember().getId());
+
+        return ResponseEntity.ok(reviewDetailRes);
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/review/dto/BestReviewDto.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/dto/BestReviewDto.java
@@ -1,0 +1,14 @@
+package com.appcenter.BJJ.domain.review.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class BestReviewDto {
+    private final Long menuId;
+    private final Long bestReviewId;
+}

--- a/src/main/java/com/appcenter/BJJ/domain/review/dto/ReviewDetailRes.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/dto/ReviewDetailRes.java
@@ -17,7 +17,7 @@ public class ReviewDetailRes {
     private final String comment;
     @Schema(description = "리뷰 별점", example = "5")
     private final Integer rating;
-    @Schema(description = "리뷰 이미지 이름", example = "23fsddfesff=3vlsdd-3sdf56.png")
+    @Schema(description = "리뷰 이미지 이름", example = "[\"aa356b24-0169-4c0c-8bf4-836ed3c6b31d.png\", \"72d2efb7-a5d6-439e-93ca-3dd578fa4f67.png\"]")
     @Setter
     private List<String> imageNames;
     @Schema(description = "리뷰 좋아요 개수", example = "123")

--- a/src/main/java/com/appcenter/BJJ/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/repository/ReviewRepository.java
@@ -1,10 +1,11 @@
 package com.appcenter.BJJ.domain.review.repository;
 
+import com.appcenter.BJJ.domain.menu.dto.MenuRatingStatsDto;
 import com.appcenter.BJJ.domain.review.domain.Review;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
 
@@ -12,4 +13,20 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
     Float findAverageRatingByMenuPairId(Long menuPairId);
 
     int countByMenuPair_Id(Long menuPairId);
+
+    @Query("""        
+        SELECT new com.appcenter.BJJ.domain.menu.dto.MenuRatingStatsDto(
+            mp.mainMenuId,
+            CAST(COALESCE(SUM(r.rating), 0) AS Long),
+            CAST(COALESCE(COUNT(r.rating), 0) AS Long)
+        )
+        FROM Review r
+        RIGHT JOIN r.menuPair mp
+        WHERE mp.mainMenuId IN :mainMenuIds
+        GROUP BY mp.mainMenuId
+    """)
+    List<MenuRatingStatsDto> calculateRatingStatsByMainMenuIds(List<Long> mainMenuIds);
+
+    @Query("SELECT COALESCE(AVG(r.rating), 0) FROM Review r")
+    Float findAverageRating();
 }

--- a/src/main/java/com/appcenter/BJJ/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/repository/ReviewRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.appcenter.BJJ.domain.review.repository;
 
 import com.appcenter.BJJ.domain.review.domain.Sort;
+import com.appcenter.BJJ.domain.review.dto.BestReviewDto;
 import com.appcenter.BJJ.domain.review.dto.MyReviewDetailRes;
 import com.appcenter.BJJ.domain.review.dto.ReviewDetailRes;
 
@@ -14,4 +15,5 @@ public interface ReviewRepositoryCustom {
     Map<String, List<MyReviewDetailRes>> findMyReviewsWithImagesAndMemberDetailsAndCafeteria(Long memberId);
     Long countMyReviewsWithImagesAndMemberDetailsByCafeteria(Long memberId, String cafeteriaName);
     List<MyReviewDetailRes> findMyReviewsWithImagesAndMemberDetailsByCafeteria(Long memberId, String cafeteriaName, int pageNumber, int pageSize);
+    List<BestReviewDto> findMostLikedReviewIdsInMainMenuIds(List<Long> mainMenuIds);
 }

--- a/src/main/java/com/appcenter/BJJ/domain/review/service/ReviewService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/service/ReviewService.java
@@ -9,6 +9,8 @@ import com.appcenter.BJJ.domain.review.domain.Sort;
 import com.appcenter.BJJ.domain.review.dto.*;
 import com.appcenter.BJJ.domain.review.dto.ReviewReq.ReviewPost;
 import com.appcenter.BJJ.domain.review.repository.ReviewRepository;
+import com.appcenter.BJJ.global.exception.CustomException;
+import com.appcenter.BJJ.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -174,5 +176,17 @@ public class ReviewService {
         }
 
         return menuPairId;
+    }
+
+    public ReviewDetailRes findReviewWithDetail(long reviewId, long memberId) {
+        log.info("[로그] findReviewWithDetail(), reviewId : {}, memberId: {}", reviewId, memberId);
+
+        ReviewDetailRes reviewDetailRes = reviewRepository.findReviewWithMenuAndMemberDetails(reviewId, memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_DETAIL_NOT_FOUND));
+
+        List<String> imageNames = imageRepository.findByReviewId(reviewId).stream().map(Image::getName).toList();
+        reviewDetailRes.setImageNames(imageNames);
+
+        return reviewDetailRes;
     }
 }

--- a/src/main/java/com/appcenter/BJJ/global/exception/ErrorCode.java
+++ b/src/main/java/com/appcenter/BJJ/global/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 아이템이 존재하지 않습니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰가 삭제되었거나 존재하지 않는 리뷰입니다."),
     MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 메뉴가 존재하지 않습니다."),
+    REVIEW_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 리뷰의 상세 정보를 불러올 수 없습니다"),
 
     //409 Conflict
     EMAIL_ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 등록된 이메일입니다."),


### PR DESCRIPTION
### 🔅 이슈번호

close #30

---

### ⏰ 작업한 내용

- 오전 4시마다 전일 메뉴의 메뉴 랭킹 업데이트 기능 추가

    - 베이지안 평균 활용 자체 평점 계산 로직 사용
    => (r*c + T*C + m*l*w) / (c + C + l*w)

    - 이 때,
    r (Ratings): 특정 메뉴 평균 점수
    c (Count): 특정 메뉴 리뷰 개수
    C (Confidence Count): 신뢰할 수 있는 리뷰 개수 = 10
    m (Maximum Rating): 리뷰 점수의 최대 값 = 5
    l (Likes): 특정 메뉴 좋아요 수
    w (Weight): 좋아요 수의 가중치 = 0.25

- 메뉴 랭킹 조회 API 추가
    - 이번 학기의 메뉴만 조회
        - 한 학기 기준: 3월 ~ 8월 / 9월 ~ 2월

    - 해당 메뉴가 주 메뉴인 리뷰의 개수가 최소 5개 이상인 메뉴만 조회

    - 최대 30등까지만 조회

    - 페이징 처리
        - 랭킹 1,2,3등은 가장 좋아요를 많이 받은 리뷰 이미지 함께 조회

- 리뷰 상세 조회 API 추가

---

### ⌛️ 스크린샷 (Optional)
![image](https://github.com/user-attachments/assets/9773ce2e-6b0a-4189-bbb0-a238082cd94d)
![image](https://github.com/user-attachments/assets/8950d518-a9e2-4ccb-9db3-90baec9f6e1a)
<i>메뉴 랭킹 조회 API</i>

![image](https://github.com/user-attachments/assets/17dd288a-9e0a-4e30-9bf0-adb8f5ff6783)
<i>리뷰 상세 조회 API</i>
