### PR TITLE
[Feat/#36] 이미지 조회 방식 변경에 따른 이미지 조회 API 수정

### DIFF
--- a/src/main/java/com/appcenter/BJJ/domain/image/ImageController.java
+++ b/src/main/java/com/appcenter/BJJ/domain/image/ImageController.java
@@ -3,6 +3,7 @@ package com.appcenter.BJJ.domain.image;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -20,12 +21,15 @@ import java.nio.file.Files;
 @Tag(name = "Image", description = "사진 API")
 public class ImageController {
 
-    @Operation(summary = "이미지 경로 조회")
-    @GetMapping
-    public ResponseEntity<byte[]> getImageByPath(String path) throws IOException {
-        log.info("[로그] GET /api/images?path={}", path);
+    @Value("${storage.images.review}")
+    private String REVIEW_IMG_DIR;
 
-        byte[] image = Files.readAllBytes(new File(path).toPath());
+    @Operation(summary = "이미지 경로 조회", deprecated = true)
+    @GetMapping
+    public ResponseEntity<byte[]> getImageByPath(String name) throws IOException {
+        log.info("[로그] GET /api/images?name={}", name);
+
+        byte[] image = Files.readAllBytes(new File(REVIEW_IMG_DIR + name).toPath());
 
         return ResponseEntity.status(HttpStatus.OK)
                 .contentType(MediaType.IMAGE_PNG)


### PR DESCRIPTION
### 🔅 이슈번호
close #36 

---

### ⏰ 작업한 내용
- 이미지 조회 API에서 path 파라미터 수정
  - path -> name
- 이미지 조회 API를 deprecated로 변경

---

### ⌛️ 스크린샷 (Optional)
![image](https://github.com/user-attachments/assets/b3de7bea-8c00-4abf-be53-855577725551)
<i>이미지 조회 API</i>
