### PR TITLE
[Feat/#61] test용 회원의 포인트 추가 & 마이페에지 response 필드값 설정 수정

### DIFF
--- a/src/main/java/com/appcenter/BJJ/domain/item/service/ItemService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/service/ItemService.java
@@ -30,9 +30,15 @@ public class ItemService {
     private static final int GACHA_RANGE = 10;
 
     public MyItemRes getMyItem(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
         return inventoryRepository.findMyItemResByMemberId(memberId).orElseGet(
                 //아이템이 하나도 없으면 null값 return (기본 아이템 장착)
-                () -> MyItemRes.builder().build()
+                () -> MyItemRes.builder()
+                        .nickname(member.getNickname())
+                        .point(member.getPoint())
+                        .build()
         );
     }
 

--- a/src/main/java/com/appcenter/BJJ/domain/member/MemberController.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/MemberController.java
@@ -1,9 +1,6 @@
 package com.appcenter.BJJ.domain.member;
 
-import com.appcenter.BJJ.domain.member.dto.LoginReq;
-import com.appcenter.BJJ.domain.member.dto.MemberOAuthVO;
-import com.appcenter.BJJ.domain.member.dto.MemberRes;
-import com.appcenter.BJJ.domain.member.dto.SignupReq;
+import com.appcenter.BJJ.domain.member.dto.*;
 import com.appcenter.BJJ.global.jwt.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -80,7 +77,7 @@ public class MemberController {
         return ResponseEntity.noContent().build();
     }
 
-    // test 회원가입 및 로그인 //
+    //TODO test용이기에 이후에 지우기
     @Operation(summary = "[test] 소셜로그인")
     @PostMapping("/test/social-login")
     public ResponseEntity<MemberRes> socialLogin(@Valid @RequestBody LoginReq loginReq) {
@@ -93,5 +90,11 @@ public class MemberController {
         Map<String, String> signupRes = new HashMap<>();
         signupRes.put("token", memberService.login(loginReq));
         return ResponseEntity.ok(signupRes);
+    }
+
+    @Operation(summary = "[test] 회원 포인트 추가")
+    @PatchMapping("/test")
+    public ResponseEntity<PointRes> updatePoint(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam int point) {
+        return ResponseEntity.ok(memberService.updatePoint(userDetails.getMember().getId(), point));
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/member/MemberService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/MemberService.java
@@ -1,10 +1,7 @@
 package com.appcenter.BJJ.domain.member;
 
 import com.appcenter.BJJ.domain.member.domain.Member;
-import com.appcenter.BJJ.domain.member.dto.LoginReq;
-import com.appcenter.BJJ.domain.member.dto.MemberOAuthVO;
-import com.appcenter.BJJ.domain.member.dto.MemberRes;
-import com.appcenter.BJJ.domain.member.dto.SignupReq;
+import com.appcenter.BJJ.domain.member.dto.*;
 import com.appcenter.BJJ.global.exception.CustomException;
 import com.appcenter.BJJ.global.exception.ErrorCode;
 import com.appcenter.BJJ.global.jwt.JwtProvider;
@@ -67,7 +64,7 @@ public class MemberService {
         log.info("MemberService.deleteMember() - 회원 탈퇴 성공");
     }
 
-    public String getToken(String providerId, Long time) {
+    private String getToken(String providerId, Long time) {
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(providerId, "");
         Authentication authentication = authenticationManager.authenticate(authenticationToken);
         log.info("MemberService-getToken: 회원이 존재합니다.");
@@ -95,7 +92,7 @@ public class MemberService {
         return newNickname;
     }
 
-    // test 회원가입 및 로그인 //
+    //TODO test용이기에 이후에 없애기
     @Transactional
     public MemberRes socialLogin(LoginReq loginReq) {
         log.info("MemberService.login() - 진입");
@@ -128,5 +125,15 @@ public class MemberService {
         member.updateMemberInfo(loginReq.getNickname(), MemberRole.USER);
 
         return getToken(member.getProviderId(), JwtProvider.validAccessTime);
+    }
+
+    @Transactional
+    public PointRes updatePoint(Long memberId, int point) {
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        member.increasePoint(point);
+        return new PointRes(member.getNickname(), member.getPoint());
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/member/dto/PointRes.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/dto/PointRes.java
@@ -1,0 +1,17 @@
+package com.appcenter.BJJ.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PointRes {
+    //TODO test용이기에 이후에 없애기
+
+    @Schema(description = "회원의 nickname", example = "이춘삼")
+    private String nickname;
+
+    @Schema(description = "회원의 point", example = "5000")
+    private int point;
+}


### PR DESCRIPTION
### 🔅 이슈번호
close #61 

---

### ⏰ 작업한 내용
- test용 회원의 포인트 추가할 수 있는 api
- 마이페이지의 response dto 필드값 수정

---

### ⌛️ 스크린샷 (Optional)
![image](https://github.com/user-attachments/assets/bf7d8a34-f176-4e9c-9aca-ff43878d796f)
<i>test용 회원의 포인트 추가 api</i>

![image](https://github.com/user-attachments/assets/7445684b-9c16-4afd-8a14-0f2de5a58cf1)
<i>마이페이지 response dto 필드 수정</i>