### PR TITLE
[Fix/#71] 식단 크롤링에서 생기는 문제 해결

### DIFF
--- a/src/main/java/com/appcenter/BJJ/domain/todaydiet/dto/DietDto.java
+++ b/src/main/java/com/appcenter/BJJ/domain/todaydiet/dto/DietDto.java
@@ -3,10 +3,10 @@ package com.appcenter.BJJ.domain.todaydiet.dto;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.LinkedList;
+import java.util.Deque;
 import java.util.List;
-import java.util.Queue;
 
 @Getter
 @ToString
@@ -15,7 +15,7 @@ public class DietDto {
     private LocalDate date;
     private Long cafeteriaId;
     private String cafeteriaCorner;
-    private Queue<String> menus;
+    private Deque<String> menus;
     private List<String> prices;
     private List<String> memberPrices;
     private List<String> calories;
@@ -27,7 +27,7 @@ public class DietDto {
         this.cafeteriaId = cafeteriaId;
         this.cafeteriaCorner = cafeteriaCorner;
         // 메인 메뉴만 받아서 입력
-        this.menus = new LinkedList<>();
+        this.menus = new ArrayDeque<>();
         menus.add(mainMenu);
         // 가격 하나만 받아서 입력
         this.prices = new ArrayList<>();
@@ -41,8 +41,8 @@ public class DietDto {
         this.notification = notification;
     }
 
-    public String pollMenu() {
-        return menus.isEmpty() ? "" : menus.poll();
+    public String pollFirstMenu() {
+        return menus.isEmpty() ? "" : menus.pollFirst();
     }
 
     public String getPrice(int index) {

--- a/src/main/java/com/appcenter/BJJ/domain/todaydiet/dto/DietDto.java
+++ b/src/main/java/com/appcenter/BJJ/domain/todaydiet/dto/DietDto.java
@@ -16,8 +16,8 @@ public class DietDto {
     private Long cafeteriaId;
     private String cafeteriaCorner;
     private Queue<String> menus;
-    private String price;
-    private String memberPrice;
+    private List<String> prices;
+    private List<String> memberPrices;
     private List<String> calories;
     private String notification;
 
@@ -29,15 +29,31 @@ public class DietDto {
         // 메인 메뉴만 받아서 입력
         this.menus = new LinkedList<>();
         menus.add(mainMenu);
-        this.price = price;
-        this.memberPrice = memberPrice;
+        // 가격 하나만 받아서 입력
+        this.prices = new ArrayList<>();
+        prices.add(price);
+        // 구성원 가격 하나만 받아서 입력
+        this.memberPrices = new ArrayList<>();
+        memberPrices.add(memberPrice);
         // 칼로리 하나만 받아서 입력
         this.calories = new ArrayList<>();
         calories.add(calorie);
         this.notification = notification;
     }
 
-    public String getCalorie() {
-        return calories.isEmpty() ? "" : calories.get(0);
+    public String pollMenu() {
+        return menus.isEmpty() ? "" : menus.poll();
+    }
+
+    public String getPrice(int index) {
+        return prices.isEmpty() ? "" : prices.get(Math.min(index, prices.size() - 1));
+    }
+
+    public String getMemberPrice(int index) {
+        return memberPrices.isEmpty() ? "" : memberPrices.get(Math.min(index, memberPrices.size() - 1));
+    }
+
+    public String getCalorie(int index) {
+        return calories.isEmpty() ? "" : calories.get(Math.min(index, calories.size() - 1));
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/todaydiet/service/DietUpdateService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/todaydiet/service/DietUpdateService.java
@@ -26,6 +26,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
@@ -104,10 +105,11 @@ public class DietUpdateService {
         }
 
         Elements wrapWeeks = wrapWeekBox.select(".wrap-week");
-        for (Element wrapWeek : wrapWeeks) {
+        for (int i = 0; i < wrapWeeks.size(); i++) {
+            Element wrapWeek = wrapWeeks.get(i);
+
             // 날짜 가져오기
-            String date = wrapWeek.select(".date").text();
-            LocalDate localDate = LocalDate.parse(date.replaceAll("\\(.*\\)", ""));
+            LocalDate localDate = LocalDate.now().with(DayOfWeek.MONDAY).plusDays(i);
 
             // 테이블 행 가져오기
             Elements rows = wrapWeek.select("tbody tr");
@@ -137,13 +139,13 @@ public class DietUpdateService {
                 }
 
                 queryStringBuilder.append(String.format("""
-                    {
-                        "date": "%s",
-                        "cafeteriaId: %s,
-                        "cafeteriaCorner": "%s %s",
-                        "menus": "%s"
-                    },
-                    """, localDate, cafeteriaId, cafeteriaName, corner , menu));
+                        {
+                            "date": "%s",
+                            "cafeteriaId: %s,
+                            "cafeteriaCorner": "%s %s",
+                            "menus": "%s"
+                        },
+                        """, localDate, cafeteriaId, cafeteriaName, corner, menu));
             }
         }
 


### PR DESCRIPTION
### 🔅 이슈번호
close #71

---

### ⏰ 작업한 내용
- 식단의 날짜를 크롤링으로 가져온 값 대신 직접 계산한 값으로 저장하도록 변경

- 크롤링으로 식단을 가져오고 저장할 때 가격(+ 구성원 가격)도 메뉴 개수에 맞게 가져오고 저장할 수 있게 수정

- 메뉴 앞에 붙은 수식어 제거하도록 수정 (ex. New), 뚝), 만우절) 등)

- 크롤링으로 가져온 메뉴를 AI가 분류했을 때 '<천원의아침밥>'이 메뉴로 들어와도 메뉴로 저장하지 않도록 수정

---

### ⌛️ 스크린샷 (Optional)