### PR TITLE
[Fix/#71] 식단 크롤링에서 생기는 문제 해결 (추가)

### DIFF
--- a/src/main/java/com/appcenter/BJJ/domain/menu/service/MenuRankingService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/menu/service/MenuRankingService.java
@@ -13,6 +13,9 @@ import com.appcenter.BJJ.domain.review.repository.ReviewRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -125,7 +128,8 @@ public class MenuRankingService {
         processMenuRankingCalculation(menuIdList);
     }
 
-    @PostConstruct  // bean 생성 후 실행
+    @Order(1) // 숫자가 낮을수록 먼저 실행
+    @EventListener(ApplicationReadyEvent.class) // Spring 애플리케이션이 완전히 실행된 후 실행 (@PostConstruct 이후)
     @Transactional
     @Scheduled(cron = "0 0 4 * * *") // 오전 4시마다 실행
     protected void updateDailyMenuRankings() {

--- a/src/main/java/com/appcenter/BJJ/domain/todaydiet/dto/DietDto.java
+++ b/src/main/java/com/appcenter/BJJ/domain/todaydiet/dto/DietDto.java
@@ -56,4 +56,8 @@ public class DietDto {
     public String getCalorie(int index) {
         return calories.isEmpty() ? "" : calories.get(Math.min(index, calories.size() - 1));
     }
+
+    public void updateMenus(Deque<String> newMenus) {
+        this.menus = newMenus;
+    }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/todaydiet/dto/DietDto.java
+++ b/src/main/java/com/appcenter/BJJ/domain/todaydiet/dto/DietDto.java
@@ -3,10 +3,7 @@ package com.appcenter.BJJ.domain.todaydiet.dto;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.List;
+import java.util.*;
 
 @Getter
 @ToString
@@ -15,7 +12,7 @@ public class DietDto {
     private LocalDate date;
     private Long cafeteriaId;
     private String cafeteriaCorner;
-    private Deque<String> menus;
+    private Queue<String> menus = new ArrayDeque<>();
     private List<String> prices;
     private List<String> memberPrices;
     private List<String> calories;
@@ -41,8 +38,8 @@ public class DietDto {
         this.notification = notification;
     }
 
-    public String pollFirstMenu() {
-        return menus.isEmpty() ? "" : menus.pollFirst();
+    public String pollMenu() {
+        return menus.isEmpty() ? "" : menus.poll();
     }
 
     public String getPrice(int index) {
@@ -57,7 +54,7 @@ public class DietDto {
         return calories.isEmpty() ? "" : calories.get(Math.min(index, calories.size() - 1));
     }
 
-    public void updateMenus(Deque<String> newMenus) {
+    public void updateMenus(Queue<String> newMenus) {
         this.menus = newMenus;
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/todaydiet/scheduler/DietScheduler.java
+++ b/src/main/java/com/appcenter/BJJ/domain/todaydiet/scheduler/DietScheduler.java
@@ -1,8 +1,10 @@
 package com.appcenter.BJJ.domain.todaydiet.scheduler;
 
 import com.appcenter.BJJ.domain.todaydiet.service.DietUpdateService;
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -14,10 +16,11 @@ public class DietScheduler {
 
     private final DietUpdateService dietUpdateService;
 
-    @PostConstruct
+    @Order(2) // 숫자가 낮을수록 먼저 실행
+    @EventListener(ApplicationReadyEvent.class) // Spring 애플리케이션이 완전히 실행된 후 실행 (@PostConstruct 이후)
     @Scheduled(cron = "0 0 7 * * MON") // 매주 월요일 오전 7시 실행
     // 스케쥴링은 프록시 메소드가 적어도 protected 이어야 함
     protected void triggerWeeklyDietUpdate() throws IOException {
-        dietUpdateService.fetchWeeklyDietInfo();
+        dietUpdateService.updateWeeklyDietWithRetry();
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/todaydiet/service/CafeteriaService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/todaydiet/service/CafeteriaService.java
@@ -87,6 +87,8 @@ public class CafeteriaService {
     @PostConstruct
     @Transactional
     protected void insertCafeteriaInformation() {
+        log.info("[로그] 식당 정보 입력 시작");
+
         // CAFETERIA_TB가 비어있는 경우에만 메서드 실행
         if (!cafeteriaRepository.findAll().isEmpty())
             return;

--- a/src/main/java/com/appcenter/BJJ/domain/todaydiet/service/DietUpdateService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/todaydiet/service/DietUpdateService.java
@@ -425,8 +425,8 @@ public class DietUpdateService {
             \\)     # 닫는 괄호 ')'
             """, "").trim();
 
-        // *, &, (, )을 제외한 모든 특수문자 제거
-        menu = menu.replaceAll("[^a-zA-Z0-9가-힣*&() ]", "");
+            // *, &, (, )을 제외한 모든 특수문자 제거
+            menu = menu.replaceAll("[^a-zA-Z0-9가-힣*&()]", "");
 
         // 메뉴에 한글이 포함되어있는지 확인하고, 한글이 없다면 빈 문자열 반환
         if (!menu.matches(".*[가-힣].*")) {

--- a/src/main/java/com/appcenter/BJJ/domain/todaydiet/service/DietUpdateService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/todaydiet/service/DietUpdateService.java
@@ -137,14 +137,33 @@ public class DietUpdateService {
                     continue;
                 }
 
-                queryStringBuilder.append(String.format("""
-                        {
-                            "date": "%s",
-                            "cafeteriaId: %s,
-                            "cafeteriaCorner": "%s %s",
-                            "menus": "%s"
-                        },
-                        """, localDate, cafeteriaId, cafeteriaName, corner, menu));
+                // "-" 3개 이상을 기준으로 식단 분리
+                String[] menuBlocks = menu.split("-{3,}");
+
+                // JSON 포맷 문자열 정의
+                String jsonFormat = """
+                    {
+                        "date": "%s",
+                        "cafeteriaId": %s,
+                        "cafeteriaCorner": "%s %s",
+                        "menus": "%s"
+                    },
+                    """;
+
+                // 첫 번째 식단 추가
+                queryStringBuilder.append(String.format(jsonFormat, localDate, cafeteriaId, cafeteriaName, corner, menuBlocks[0]));
+
+                // 두 번째 블록부터 "국밥"이 포함된 식단 추가
+                for (int j = 1; j < menuBlocks.length; j++) {
+                    if (menuBlocks[j].contains("국밥")) {
+                        // "*국밥*" 패턴을 제거
+                        String cleanedMenu = menuBlocks[j].replaceAll("\\*국밥\\*", "").trim();
+                        if (!cleanedMenu.isEmpty()) {
+                            queryStringBuilder.append(String.format(jsonFormat, localDate, cafeteriaId, cafeteriaName, corner, cleanedMenu));
+                        }
+                        break;  // 국밥 식단은 하나만 추가
+                    }
+                }
             }
         }
 

--- a/src/main/java/com/appcenter/BJJ/domain/todaydiet/service/DietUpdateService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/todaydiet/service/DietUpdateService.java
@@ -48,6 +48,7 @@ public class DietUpdateService {
     private final TodayDietService todayDietService;
     private final CafeteriaService cafeteriaService;
 
+    // TODO: 3회 재시도 이후 실패 시 Slack 알림 및 추가 재시도 등 필요
     @Async
     @Retryable(
         retryFor = {
@@ -58,6 +59,15 @@ public class DietUpdateService {
         maxAttempts = 3,
         backoff = @Backoff(delay = 300000) // 5분 뒤 재시도
     )
+    public void updateWeeklyDietWithRetry() throws IOException {
+        try {
+            updateWeeklyDiet();
+        } catch (Exception e) {
+            log.error("[로그] 식단 업데이트 중 오류 발생", e);
+            throw e; // 예외를 다시 던져야 Retryable이 동작
+        }
+    }
+
     public void updateWeeklyDiet() throws IOException {
         // 오늘 날짜의 식단 데이터가 이미 존재하면 추출 스킵
         if (todayDietService.checkThisWeekDietDataExist()) {

--- a/src/main/java/com/appcenter/BJJ/domain/todaydiet/service/DietUpdateService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/todaydiet/service/DietUpdateService.java
@@ -80,7 +80,7 @@ public class DietUpdateService {
 
         // 식단 데이터 가공 및 저장
         List<TodayDiet> todayDiets = dietDtos.stream()
-                .flatMap(dietDto -> splitDietByCalories(dietDto).stream())
+                .flatMap(dietDto -> cleanAndSplitDiets(dietDto).stream())
                 .map(this::buildTodayDietWithMenus)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
@@ -296,14 +296,14 @@ public class DietUpdateService {
      * 칼로리 또는 가격, 구성원 가격이 여러 개인 경우 각각 하나의 식단으로 분리,
      * 추가로 '<천원의아침밥>'이라는 문자열이 첫 번째 메뉴에 있는 경우 삭제
      **/
-    private List<DietDto> splitDietByCalories(DietDto dietDto) {
+    private List<DietDto> cleanAndSplitDiets(DietDto dietDto) {
         Deque<String> menus = dietDto.getMenus();
 
         // 모든 메뉴 정제 (슬래시 기준 분리 -> '천원의아침밥' 제거 → 수식어 제거 -> 특수문자 제거)
         List<String> cleanedMenus = menus.stream()
                 .flatMap(menu -> Arrays.stream(menu.split("/"))
                         .map(String::trim)) // 슬래시로 분리 후 앞뒤 공백 제거
-                .map(this::cleanMenu)
+                .map(this::cleanMenuText)
                 .filter(menu -> !menu.isEmpty()) // 빈 문자열 제거
                 .toList();
 
@@ -355,7 +355,7 @@ public class DietUpdateService {
      * *, &, (, )을 제외한 모든 특수문자 제거
      * 메뉴에 한글이 포함되어있는지 확인하고, 한글이 없다면 빈 문자열 반환
      **/
-    private String cleanMenu(String menu) {
+    private String cleanMenuText(String menu) {
         if (menu == null) return "";
 
         // '<천원의아침밥>' 제거 (앞뒤 꺽쇠 없어도 제거 가능)


### PR DESCRIPTION
### 🔅 이슈번호
close #71 

---

### ⏰ 작업한 내용
- AI가 프롬프트 요구사항과 다르게 변환한 메뉴 문자열을 찾아 추가적으로 변환하도록 수정
  - '운영없음'이 메뉴에 포함될 경우 해당 식단 건너뛰기
  - 슬래시로 연결된 메뉴가 있을 경우 분리
  - *, &, (, )을 제외한 모든 특수문자 제거
- 사범대식당의 국밥 식단도 가져올 수 있도록 수정
- @PostConstruct로 실행되던 메서드인 식당 정보 입력 메서드,메뉴 랭킹 업데이트 메서드, 식단 업데이트 메서드가 순서대로 실행되도록 변경
- 리팩토링
  - 복잡한 로직에서 메서드 추출
  - 메서드명 및 변수명 변경

---

### ⌛️ 스크린샷 (Optional)