### PR TITLE
[Feat/#60] 알림 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ out/
 application.properties
 application-prod.properties
 application-dev.properties
+
+# Firebase Admin SDK key
+inu-bjj-project-firebase-adminsdk.json

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
 
 	// Spring AI
 	implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
+
+	// Firebase Admin SDK
+	implementation 'com.google.firebase:firebase-admin:9.4.3'
 }
 
 dependencyManagement {

--- a/src/main/java/com/appcenter/BJJ/domain/member/MemberController.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/MemberController.java
@@ -67,7 +67,7 @@ public class MemberController {
 
     @Operation(summary = "알림 설정 토글", description = "알림을 켠 경우 true, 알림을 끈 경우 false 반환")
     @PatchMapping("/notification")
-    public ResponseEntity<?> toggleNotification(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<Boolean> toggleNotification(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         log.info("[로그] PATCH /api/members/notification, memberNickname: {}", userDetails.getNickname());
 
         boolean isNotificationActive = memberService.toggleNotification(userDetails.getMember().getId());

--- a/src/main/java/com/appcenter/BJJ/domain/member/MemberController.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/MemberController.java
@@ -65,6 +65,15 @@ public class MemberController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "알림 설정 토글", description = "알림을 켠 경우 true, 알림을 끈 경우 false 반환")
+    @PatchMapping("/notification")
+    public ResponseEntity<?> toggleNotification(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        log.info("[로그] PATCH /api/members/notification, memberNickname: {}", userDetails.getNickname());
+
+        boolean isNotificationActive = memberService.toggleNotification(userDetails.getMember().getId());
+        return ResponseEntity.ok(isNotificationActive);
+    }
+
     @Operation(summary = "redirect용 (사용X)")
     @GetMapping("/sign-up")
     public ResponseEntity<?> resolveRedirectSign(@RequestParam String email, @RequestParam String token) {

--- a/src/main/java/com/appcenter/BJJ/domain/member/MemberRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/MemberRepository.java
@@ -1,9 +1,11 @@
 package com.appcenter.BJJ.domain.member;
 
 import com.appcenter.BJJ.domain.member.domain.Member;
+import com.appcenter.BJJ.domain.notification.dto.NotifiableMemberDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -19,4 +21,17 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByNickname(String nickname);
 
     boolean existsByProviderId(String providerId);
+
+    @Query("""
+        SELECT new com.appcenter.BJJ.domain.notification.dto.NotifiableMemberDto(
+                ml.menuId,
+                m.id,
+                m.nickname
+        )
+        FROM Member m
+        INNER JOIN MenuLike ml ON m.id = ml.memberId
+        WHERE ml.menuId IN :menuIds
+            AND m.isNotificationEnabled = true
+    """)
+    List<NotifiableMemberDto> findNotifiableMembersByLikedMenus(List<Long> menuIds);
 }

--- a/src/main/java/com/appcenter/BJJ/domain/member/MemberRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/MemberRepository.java
@@ -25,8 +25,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("""
         SELECT new com.appcenter.BJJ.domain.notification.dto.NotifiableMemberDto(
                 ml.menuId,
-                m.id,
-                m.nickname
+                m.id
         )
         FROM Member m
         INNER JOIN MenuLike ml ON m.id = ml.memberId

--- a/src/main/java/com/appcenter/BJJ/domain/member/MemberService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/MemberService.java
@@ -136,4 +136,15 @@ public class MemberService {
         member.increasePoint(point);
         return new PointRes(member.getNickname(), member.getPoint());
     }
+
+    @Transactional
+    public boolean toggleNotification(long memberId) {
+        log.info("[로그] toggleNotification(), memberId : {}", memberId);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        member.toggleNotification();
+        return member.getIsNotificationEnabled();
+    }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/member/domain/Member.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/domain/Member.java
@@ -31,6 +31,8 @@ public class Member {
 
     private OAuth2Client oAuth2Client;
 
+    private Boolean isNotificationEnabled;
+
 
     @Builder
     private Member(String nickname, String email, String provider, String providerId, OAuth2Client oAuth2Client) {
@@ -41,6 +43,7 @@ public class Member {
         this.point = 0;
         this.role = MemberRole.GUEST;
         this.oAuth2Client = oAuth2Client;
+        this.isNotificationEnabled = true;
     }
 
     public void updateMemberInfo(String nickname, MemberRole role) {
@@ -62,6 +65,10 @@ public class Member {
 
     public void updateOauthToken(OAuth2Client oAuth2Client) {
         this.oAuth2Client = oAuth2Client;
+    }
+
+    public void toggleNotification() {
+        this.isNotificationEnabled = !this.isNotificationEnabled;
     }
 
     // test용 메소드

--- a/src/main/java/com/appcenter/BJJ/domain/notification/controller/DeviceTokenController.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/controller/DeviceTokenController.java
@@ -1,0 +1,33 @@
+package com.appcenter.BJJ.domain.notification.controller;
+
+import com.appcenter.BJJ.domain.notification.service.DeviceTokenService;
+import com.appcenter.BJJ.global.jwt.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/device-tokens")
+@RequiredArgsConstructor
+@Tag(name = "DeviceToken", description = "FCM 기기 토큰 API")
+public class DeviceTokenController {
+
+    private final DeviceTokenService deviceTokenService;
+
+    @PostMapping
+    @Operation(summary = "FCM 기기 토큰 등록", description = "이미 등록된 기기 토큰 등록 시도 시 해당 기기 토큰의 ID 반환")
+    public ResponseEntity<Long> postDeviceToken(String token, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        log.info("[로그] POST /api/device-tokens, token: {}, memberNickname : {}", token, userDetails.getNickname());
+
+        Long deviceTokenId = deviceTokenService.createDeviceToken(token, userDetails.getMember().getId());
+
+        return ResponseEntity.ok(deviceTokenId);
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/domain/notification/domain/DeviceToken.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/domain/DeviceToken.java
@@ -1,0 +1,39 @@
+package com.appcenter.BJJ.domain.notification.domain;
+
+
+import com.appcenter.BJJ.domain.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.threeten.bp.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "device_token_tb")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeviceToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @Column(unique = true, nullable = false)
+    private String token;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime lastUsedAt;
+
+    @Builder
+    private DeviceToken(Member member, String token) {
+        this.member = member;
+        this.token = token;
+        this.createdAt = LocalDateTime.now();
+        this.lastUsedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/domain/notification/domain/DeviceToken.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/domain/DeviceToken.java
@@ -7,7 +7,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.threeten.bp.LocalDateTime;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Entity
@@ -42,5 +43,9 @@ public class DeviceToken {
 
     public void deactivate() {
         this.isActive = false;
+    }
+
+    public void updateLastUsedAt(LocalDateTime dateTime) {
+        this.lastUsedAt = dateTime;
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/notification/domain/DeviceToken.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/domain/DeviceToken.java
@@ -29,11 +29,18 @@ public class DeviceToken {
 
     private LocalDateTime lastUsedAt;
 
+    private Boolean isActive;
+
     @Builder
     private DeviceToken(Member member, String token) {
         this.member = member;
         this.token = token;
         this.createdAt = LocalDateTime.now();
         this.lastUsedAt = LocalDateTime.now();
+        this.isActive = true;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/notification/dto/MemberDeviceTokenDto.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/dto/MemberDeviceTokenDto.java
@@ -1,0 +1,14 @@
+package com.appcenter.BJJ.domain.notification.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberDeviceTokenDto {
+    private final Long memberId;
+    private final String token;
+}

--- a/src/main/java/com/appcenter/BJJ/domain/notification/dto/NotifiableMemberDto.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/dto/NotifiableMemberDto.java
@@ -11,5 +11,4 @@ import lombok.ToString;
 public class NotifiableMemberDto {
     private final Long menuId;
     private final Long memberId;
-    private final String memberNickname;
 }

--- a/src/main/java/com/appcenter/BJJ/domain/notification/dto/NotifiableMemberDto.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/dto/NotifiableMemberDto.java
@@ -1,0 +1,15 @@
+package com.appcenter.BJJ.domain.notification.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class NotifiableMemberDto {
+    private final Long menuId;
+    private final Long memberId;
+    private final String memberNickname;
+}

--- a/src/main/java/com/appcenter/BJJ/domain/notification/dto/NotificationInfoDto.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/dto/NotificationInfoDto.java
@@ -1,0 +1,18 @@
+package com.appcenter.BJJ.domain.notification.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@Builder
+@ToString
+public class NotificationInfoDto {
+    private final String memberNickname;
+    private final String menuName;
+    private final String cafeteriaName;
+    private final String cafeteriaCorner;
+    private final List<String> fcmTokens;
+}

--- a/src/main/java/com/appcenter/BJJ/domain/notification/dto/NotificationInfoDto.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/dto/NotificationInfoDto.java
@@ -10,7 +10,6 @@ import java.util.List;
 @Builder
 @ToString
 public class NotificationInfoDto {
-    private final String memberNickname;
     private final String menuName;
     private final String cafeteriaName;
     private final String cafeteriaCorner;

--- a/src/main/java/com/appcenter/BJJ/domain/notification/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/repository/DeviceTokenRepository.java
@@ -5,6 +5,7 @@ import com.appcenter.BJJ.domain.notification.dto.MemberDeviceTokenDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,6 +19,9 @@ public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> 
         )
         FROM DeviceToken dt
         WHERE dt.member.id IN :memberIds
+            AND dt.isActive = true
     """)
-    List<MemberDeviceTokenDto> findTokensInMemberIds(List<Long> memberIds);
+    List<MemberDeviceTokenDto> findActiveTokensInMemberIds(List<Long> memberIds);
+
+    List<DeviceToken> findAllByTokenIn(Collection<String> tokens);
 }

--- a/src/main/java/com/appcenter/BJJ/domain/notification/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/repository/DeviceTokenRepository.java
@@ -1,0 +1,10 @@
+package com.appcenter.BJJ.domain.notification.repository;
+
+import com.appcenter.BJJ.domain.notification.domain.DeviceToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
+    Optional<DeviceToken> findByToken(String token);
+}

--- a/src/main/java/com/appcenter/BJJ/domain/notification/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/repository/DeviceTokenRepository.java
@@ -1,10 +1,23 @@
 package com.appcenter.BJJ.domain.notification.repository;
 
 import com.appcenter.BJJ.domain.notification.domain.DeviceToken;
+import com.appcenter.BJJ.domain.notification.dto.MemberDeviceTokenDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
     Optional<DeviceToken> findByToken(String token);
+
+    @Query("""
+        SELECT new com.appcenter.BJJ.domain.notification.dto.MemberDeviceTokenDto(
+            dt.member.id,
+            dt.token
+        )
+        FROM DeviceToken dt
+        WHERE dt.member.id IN :memberIds
+    """)
+    List<MemberDeviceTokenDto> findTokensInMemberIds(List<Long> memberIds);
 }

--- a/src/main/java/com/appcenter/BJJ/domain/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/scheduler/NotificationScheduler.java
@@ -1,0 +1,36 @@
+package com.appcenter.BJJ.domain.notification.scheduler;
+
+import com.appcenter.BJJ.domain.notification.dto.NotificationInfoDto;
+import com.appcenter.BJJ.domain.notification.service.DietNotificationService;
+import com.appcenter.BJJ.domain.notification.service.FcmService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationScheduler {
+
+    private final DietNotificationService dietNotificationService;
+    private final FcmService fcmService;
+
+    @Scheduled(cron = "0 30 7 * * *") // 매일 오전 7시 30분
+    protected void sendDietNotifications() {
+        LocalDate today = LocalDate.now();
+        log.info("[로그] {} 식단 메뉴 알림 스케줄러 시작", today);
+
+        Map<Long, List<NotificationInfoDto>> notificationTargets =
+                dietNotificationService.collectNotificationTargets(today);
+
+        fcmService.sendMessage(notificationTargets);
+
+        log.info("[로그] {} 식단 메뉴 알림 스케줄러 종료", today);
+    }
+
+}

--- a/src/main/java/com/appcenter/BJJ/domain/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/scheduler/NotificationScheduler.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @Component
@@ -25,7 +24,7 @@ public class NotificationScheduler {
         LocalDate today = LocalDate.now();
         log.info("[로그] {} 식단 메뉴 알림 스케줄러 시작", today);
 
-        Map<Long, List<NotificationInfoDto>> notificationTargets =
+        List<NotificationInfoDto> notificationTargets =
                 dietNotificationService.collectNotificationTargets(today);
 
         fcmService.sendMessage(notificationTargets);

--- a/src/main/java/com/appcenter/BJJ/domain/notification/service/DeviceTokenService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/service/DeviceTokenService.java
@@ -1,0 +1,47 @@
+package com.appcenter.BJJ.domain.notification.service;
+
+import com.appcenter.BJJ.domain.member.MemberRepository;
+import com.appcenter.BJJ.domain.member.domain.Member;
+import com.appcenter.BJJ.domain.notification.domain.DeviceToken;
+import com.appcenter.BJJ.domain.notification.repository.DeviceTokenRepository;
+import com.appcenter.BJJ.global.exception.CustomException;
+import com.appcenter.BJJ.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DeviceTokenService {
+
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Long createDeviceToken(String token, Long memberId) {
+        log.info("[로그] createDeviceToken(), token : {}, memberId : {}", token, memberId);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 이미 동일한 기기 토큰이 등록된 경우 해당 토큰의 ID 반환
+        Optional<DeviceToken> optionalDeviceToken = deviceTokenRepository.findByToken(token);
+        if (optionalDeviceToken.isPresent()) {
+            return optionalDeviceToken.get().getId();
+        }
+
+        DeviceToken deviceToken = DeviceToken.builder()
+                .member(member)
+                .token(token)
+                .build();
+
+        return deviceTokenRepository.save(deviceToken).getId();
+    }
+
+    // TODO: 유효하지 않은 토큰 제거 로직 추가 필요
+}

--- a/src/main/java/com/appcenter/BJJ/domain/notification/service/DeviceTokenService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/service/DeviceTokenService.java
@@ -11,7 +11,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -43,5 +46,9 @@ public class DeviceTokenService {
         return deviceTokenRepository.save(deviceToken).getId();
     }
 
-    // TODO: 유효하지 않은 토큰 제거 로직 추가 필요
+    @Transactional
+    public void deactivateTokens(Set<String> tokens) {
+        List<DeviceToken> deviceTokens = deviceTokenRepository.findAllByTokenIn(new ArrayList<>(tokens));
+        deviceTokens.forEach(DeviceToken::deactivate);
+    }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/notification/service/DeviceTokenService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/service/DeviceTokenService.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -50,5 +51,12 @@ public class DeviceTokenService {
     public void deactivateTokens(Set<String> tokens) {
         List<DeviceToken> deviceTokens = deviceTokenRepository.findAllByTokenIn(new ArrayList<>(tokens));
         deviceTokens.forEach(DeviceToken::deactivate);
+    }
+
+    @Transactional
+    public void updateLastUsedAt(Set<String> tokenValues) {
+        List<DeviceToken> tokens = deviceTokenRepository.findAllByTokenIn(new ArrayList<>(tokenValues));
+        LocalDateTime now = LocalDateTime.now();
+        tokens.forEach(token -> token.updateLastUsedAt(now));
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/notification/service/DietNotificationService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/service/DietNotificationService.java
@@ -1,0 +1,84 @@
+package com.appcenter.BJJ.domain.notification.service;
+
+import com.appcenter.BJJ.domain.member.MemberRepository;
+import com.appcenter.BJJ.domain.menu.dto.MenuInfoDto;
+import com.appcenter.BJJ.domain.menu.repository.MenuRepository;
+import com.appcenter.BJJ.domain.notification.dto.NotificationInfoDto;
+import com.appcenter.BJJ.domain.notification.dto.NotifiableMemberDto;
+import com.appcenter.BJJ.domain.notification.dto.MemberDeviceTokenDto;
+import com.appcenter.BJJ.domain.notification.repository.DeviceTokenRepository;
+import com.appcenter.BJJ.domain.todaydiet.repository.TodayDietRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DietNotificationService {
+
+    private final MemberRepository memberRepository;
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final TodayDietRepository todayDietRepository;
+    private final MenuRepository menuRepository;
+
+    public Map<Long, List<NotificationInfoDto>> collectNotificationTargets(LocalDate date) {
+        log.info("[로그] {} 날짜의 메뉴 알림 시작", date);
+
+        // 해당 날짜 식단의 메인 및 서브 메뉴 ID 조회
+        Set<Long> menuIdSet = new HashSet<>();
+        menuIdSet.addAll(todayDietRepository.findMainMenuIdsByDate(date));
+        menuIdSet.addAll(todayDietRepository.findSubMenuIdsByDate(date));  // 조회 시 서브 메뉴 ID가 Null인 경우는 제외
+        List<Long> menuIdList = menuIdSet.stream().toList();
+        log.debug("[로그] 오늘 식단의 메인 메뉴 및 서브 메뉴 ID 조회, menuIdList.size = {}, menuIdList = {}", menuIdList.size(), menuIdList);
+
+        // 메뉴 ID 목록의 상세 정보 조회 (메뉴 이름, 식당 이름, 식당 코너 이름)
+        List<MenuInfoDto> menuInfoDtos = menuRepository.findMenusWithCafeteriaInMenuIds(menuIdList);
+        Map<Long, MenuInfoDto> menuInfoMap = menuInfoDtos.stream()
+                .collect(Collectors.toMap(MenuInfoDto::getMenuId, Function.identity()));
+        log.debug("[로그] 메뉴 ID 목록의 상세 정보 조회, menuInfoMap.size = {}, menuInfoMap = {}", menuInfoMap.size(), menuInfoMap);
+
+        // 각 메뉴에 좋아요를 누른 회원 중 알림 설정을 켜 놓은 회원 정보 조회
+        List<NotifiableMemberDto> notifiableMemberDtos = memberRepository.findNotifiableMembersByLikedMenus(menuIdList);
+        List<Long> memberIds = notifiableMemberDtos.stream().map(NotifiableMemberDto::getMemberId).distinct().toList();
+        log.debug("[로그] 각 메뉴에 좋아요를 누른 회원 중 알림 설정을 켜 놓은 회원 정보 조회, notifiableMemberDtos.size = {}, notifiableMemberDtos = {}", notifiableMemberDtos.size(), notifiableMemberDtos);
+        log.debug("[로그] 각 메뉴에 좋아요를 누른 회원 중 알림 설정을 켜 놓은 회원 ID 조회 (중복 X), memberIds.size = {}, memberIds = {}", memberIds.size(), memberIds);
+
+        // 각 회원의 기기 토큰 조회
+        List<MemberDeviceTokenDto> memberDeviceTokenDtos = deviceTokenRepository.findTokensInMemberIds(memberIds);
+        Map<Long, List<String>> memberTokenMap = memberDeviceTokenDtos.stream()
+                .collect(Collectors.groupingBy(MemberDeviceTokenDto::getMemberId,
+                        Collectors.mapping(MemberDeviceTokenDto::getToken, Collectors.toList())));
+        log.debug("[로그] 각 회원의 기기 토큰 중 알림 설정을 켜 놓은 기기 토큰 조회, memberTokenMap.size = {}, memberTokenMap = {}", memberTokenMap.size(), memberTokenMap);
+
+        // 각 회원 별 메뉴 정보 및 기기 토큰 목록으로 취합
+        Map<Long, List<NotificationInfoDto>> notificationInfoMap = new HashMap<>();
+        for (NotifiableMemberDto notifiableMemberDto : notifiableMemberDtos) {
+            MenuInfoDto menuInfo = menuInfoMap.get(notifiableMemberDto.getMenuId());
+            if (menuInfo == null) continue;
+
+            List<String> fcmTokens = memberTokenMap.getOrDefault(notifiableMemberDto.getMemberId(), List.of());
+
+            NotificationInfoDto notification = NotificationInfoDto.builder()
+                    .memberNickname(notifiableMemberDto.getMemberNickname())
+                    .menuName(menuInfo.getMenuName())
+                    .cafeteriaName(menuInfo.getCafeteriaName())
+                    .cafeteriaCorner(menuInfo.getCafeteriaCorner())
+                    .fcmTokens(fcmTokens)
+                    .build();
+
+            notificationInfoMap
+                    .computeIfAbsent(notifiableMemberDto.getMemberId(), k -> new ArrayList<>())
+                    .add(notification);
+        }
+
+        return notificationInfoMap;
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/domain/notification/service/DietNotificationService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/service/DietNotificationService.java
@@ -3,9 +3,9 @@ package com.appcenter.BJJ.domain.notification.service;
 import com.appcenter.BJJ.domain.member.MemberRepository;
 import com.appcenter.BJJ.domain.menu.dto.MenuInfoDto;
 import com.appcenter.BJJ.domain.menu.repository.MenuRepository;
-import com.appcenter.BJJ.domain.notification.dto.NotificationInfoDto;
-import com.appcenter.BJJ.domain.notification.dto.NotifiableMemberDto;
 import com.appcenter.BJJ.domain.notification.dto.MemberDeviceTokenDto;
+import com.appcenter.BJJ.domain.notification.dto.NotifiableMemberDto;
+import com.appcenter.BJJ.domain.notification.dto.NotificationInfoDto;
 import com.appcenter.BJJ.domain.notification.repository.DeviceTokenRepository;
 import com.appcenter.BJJ.domain.todaydiet.repository.TodayDietRepository;
 import lombok.RequiredArgsConstructor;
@@ -29,56 +29,94 @@ public class DietNotificationService {
     private final TodayDietRepository todayDietRepository;
     private final MenuRepository menuRepository;
 
-    public Map<Long, List<NotificationInfoDto>> collectNotificationTargets(LocalDate date) {
+    public List<NotificationInfoDto> collectNotificationTargets(LocalDate date) {
         log.info("[로그] {} 날짜의 메뉴 알림 시작", date);
 
-        // 해당 날짜 식단의 메인 및 서브 메뉴 ID 조회
+        // 해당 날짜의 모든 메뉴 ID 수집
+        List<Long> menuIds = collectMenuIdsByDate(date);
+
+        // 메뉴 ID → 메뉴 상세 정보 매핑
+        Map<Long, MenuInfoDto> menuIdToMenuInfoMap = mapMenuIdToInfo(menuIds);
+
+        // 알림 수신 동의 + 메뉴 좋아요한 회원 목록 조회
+        List<NotifiableMemberDto> notifiableMemberDtos = memberRepository.findNotifiableMembersByLikedMenus(menuIds);
+        Set<Long> memberIds = notifiableMemberDtos.stream()
+                .map(NotifiableMemberDto::getMemberId)
+                .collect(Collectors.toSet());
+
+        log.debug("[로그] 알림 대상 회원 수: {}, 일부 메뉴 및 회원 정보: {}", memberIds.size(), notifiableMemberDtos.stream().limit(5).toList());
+
+        // 회원 ID → FCM 토큰 리스트 매핑
+        Map<Long, List<String>> memberIdToTokensMap = mapMemberIdToTokens(memberIds);
+
+        // 메뉴 ID → FCM 토큰 리스트 매핑
+        Map<Long, List<String>> menuIdToTokens = mapMenuIdToTokens(notifiableMemberDtos, memberIdToTokensMap, menuIdToMenuInfoMap);
+
+        // 메뉴별 FCM 알림 정보 구성
+        return menuIdToTokens.entrySet().stream()
+                .map(entry -> {
+                    Long menuId = entry.getKey();
+                    List<String> tokens = entry.getValue();
+                    MenuInfoDto menuInfoDto = menuIdToMenuInfoMap.get(menuId);
+
+                    return NotificationInfoDto.builder()
+                            .menuName(menuInfoDto.getMenuName())
+                            .cafeteriaName(menuInfoDto.getCafeteriaName())
+                            .cafeteriaCorner(menuInfoDto.getCafeteriaCorner())
+                            .fcmTokens(tokens)
+                            .build();
+                }).toList();
+    }
+
+    private List<Long> collectMenuIdsByDate(LocalDate date) {
         Set<Long> menuIdSet = new HashSet<>();
         menuIdSet.addAll(todayDietRepository.findMainMenuIdsByDate(date));
         menuIdSet.addAll(todayDietRepository.findSubMenuIdsByDate(date));  // 조회 시 서브 메뉴 ID가 Null인 경우는 제외
-        List<Long> menuIdList = menuIdSet.stream().toList();
-        log.debug("[로그] 오늘 식단의 메인 메뉴 및 서브 메뉴 ID 조회, menuIdList.size = {}, menuIdList = {}", menuIdList.size(), menuIdList);
+        List<Long> result = menuIdSet.stream().toList();
+        log.debug("[로그] 오늘 식단의 메인 메뉴 및 서브 메뉴 ID 조회, 총 메뉴 개수 = {}, 메뉴 일부 = {}", result.size(), result.stream().limit(5).toList());
 
-        // 메뉴 ID 목록의 상세 정보 조회 (메뉴 이름, 식당 이름, 식당 코너 이름)
+        return result;
+    }
+
+    private Map<Long, MenuInfoDto> mapMenuIdToInfo(List<Long> menuIdList) {
         List<MenuInfoDto> menuInfoDtos = menuRepository.findMenusWithCafeteriaInMenuIds(menuIdList);
-        Map<Long, MenuInfoDto> menuInfoMap = menuInfoDtos.stream()
+        Map<Long, MenuInfoDto> result = menuInfoDtos.stream()
                 .collect(Collectors.toMap(MenuInfoDto::getMenuId, Function.identity()));
-        log.debug("[로그] 메뉴 ID 목록의 상세 정보 조회, menuInfoMap.size = {}, menuInfoMap = {}", menuInfoMap.size(), menuInfoMap);
+        log.debug("[로그] 메뉴 상세 정보 조회, 총 메뉴 상세 정보 개수  = {}, 메뉴 상세 일부 = {}", result.size(), result.entrySet().stream().limit(5).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+        return result;
+    }
 
-        // 각 메뉴에 좋아요를 누른 회원 중 알림 설정을 켜 놓은 회원 정보 조회
-        List<NotifiableMemberDto> notifiableMemberDtos = memberRepository.findNotifiableMembersByLikedMenus(menuIdList);
-        List<Long> memberIds = notifiableMemberDtos.stream().map(NotifiableMemberDto::getMemberId).distinct().toList();
-        log.debug("[로그] 각 메뉴에 좋아요를 누른 회원 중 알림 설정을 켜 놓은 회원 정보 조회, notifiableMemberDtos.size = {}, notifiableMemberDtos = {}", notifiableMemberDtos.size(), notifiableMemberDtos);
-        log.debug("[로그] 각 메뉴에 좋아요를 누른 회원 중 알림 설정을 켜 놓은 회원 ID 조회 (중복 X), memberIds.size = {}, memberIds = {}", memberIds.size(), memberIds);
-
-        // 각 회원의 기기 토큰 조회
-        List<MemberDeviceTokenDto> memberDeviceTokenDtos = deviceTokenRepository.findTokensInMemberIds(memberIds);
-        Map<Long, List<String>> memberTokenMap = memberDeviceTokenDtos.stream()
+    private Map<Long, List<String>> mapMemberIdToTokens(Set<Long> memberIds) {
+        List<MemberDeviceTokenDto> memberDeviceTokenDtos = deviceTokenRepository.findTokensInMemberIds(memberIds.stream().toList());
+        Map<Long, List<String>> result = memberDeviceTokenDtos.stream()
                 .collect(Collectors.groupingBy(MemberDeviceTokenDto::getMemberId,
                         Collectors.mapping(MemberDeviceTokenDto::getToken, Collectors.toList())));
-        log.debug("[로그] 각 회원의 기기 토큰 중 알림 설정을 켜 놓은 기기 토큰 조회, memberTokenMap.size = {}, memberTokenMap = {}", memberTokenMap.size(), memberTokenMap);
+        log.debug("[로그] 회원별 기기 토큰 조회, 총 토큰 개수 = {}, 회원별 토큰 일부 = {}", memberDeviceTokenDtos.size(), result.entrySet().stream().limit(5).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+        return result;
+    }
 
-        // 각 회원 별 메뉴 정보 및 기기 토큰 목록으로 취합
-        Map<Long, List<NotificationInfoDto>> notificationInfoMap = new HashMap<>();
+    private static Map<Long, List<String>> mapMenuIdToTokens(
+            List<NotifiableMemberDto> notifiableMemberDtos,
+            Map<Long, List<String>> memberIdToTokensMap,
+            Map<Long, MenuInfoDto> menuIdToMenuInfoMap
+    ) {
+        Map<Long, Set<String>> menuIdToTokensSet = new HashMap<>();
+
         for (NotifiableMemberDto notifiableMemberDto : notifiableMemberDtos) {
-            MenuInfoDto menuInfo = menuInfoMap.get(notifiableMemberDto.getMenuId());
-            if (menuInfo == null) continue;
+            List<String> tokens = memberIdToTokensMap.getOrDefault(notifiableMemberDto.getMemberId(), List.of());
+            if (tokens.isEmpty()) continue;
 
-            List<String> fcmTokens = memberTokenMap.getOrDefault(notifiableMemberDto.getMemberId(), List.of());
+            if (!menuIdToMenuInfoMap.containsKey(notifiableMemberDto.getMenuId())) continue;
 
-            NotificationInfoDto notification = NotificationInfoDto.builder()
-                    .memberNickname(notifiableMemberDto.getMemberNickname())
-                    .menuName(menuInfo.getMenuName())
-                    .cafeteriaName(menuInfo.getCafeteriaName())
-                    .cafeteriaCorner(menuInfo.getCafeteriaCorner())
-                    .fcmTokens(fcmTokens)
-                    .build();
-
-            notificationInfoMap
-                    .computeIfAbsent(notifiableMemberDto.getMemberId(), k -> new ArrayList<>())
-                    .add(notification);
+            menuIdToTokensSet
+                    .computeIfAbsent(notifiableMemberDto.getMenuId(), k -> new HashSet<>())
+                    .addAll(tokens);
         }
 
-        return notificationInfoMap;
+        return menuIdToTokensSet.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> new ArrayList<>(e.getValue())
+                ));
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/notification/service/DietNotificationService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/service/DietNotificationService.java
@@ -87,11 +87,11 @@ public class DietNotificationService {
     }
 
     private Map<Long, List<String>> mapMemberIdToTokens(Set<Long> memberIds) {
-        List<MemberDeviceTokenDto> memberDeviceTokenDtos = deviceTokenRepository.findTokensInMemberIds(memberIds.stream().toList());
+        List<MemberDeviceTokenDto> memberDeviceTokenDtos = deviceTokenRepository.findActiveTokensInMemberIds(memberIds.stream().toList());
         Map<Long, List<String>> result = memberDeviceTokenDtos.stream()
                 .collect(Collectors.groupingBy(MemberDeviceTokenDto::getMemberId,
                         Collectors.mapping(MemberDeviceTokenDto::getToken, Collectors.toList())));
-        log.debug("[로그] 회원별 기기 토큰 조회, 총 토큰 개수 = {}, 회원별 토큰 일부 = {}", memberDeviceTokenDtos.size(), result.entrySet().stream().limit(5).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+        log.debug("[로그] 회원별 활성화 된 기기 토큰 조회, 총 토큰 개수 = {}, 회원별 토큰 일부 = {}", memberDeviceTokenDtos.size(), result.entrySet().stream().limit(5).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
         return result;
     }
 

--- a/src/main/java/com/appcenter/BJJ/domain/notification/service/FcmAsyncService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/service/FcmAsyncService.java
@@ -6,13 +6,18 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class FcmAsyncService {
 
     @Async("fcmTaskExecutor")
-    protected void sendMulticastWithRetry(MulticastMessage message, String menuName, int attempt) {
+    protected CompletableFuture<List<String>> sendMulticastWithRetry(MulticastMessage message, List<String> tokens, String menuName, int attempt) {
+        List<String> invalidTokens = new ArrayList<>();
         try {
             BatchResponse response = FirebaseMessaging.getInstance().sendEachForMulticast(message);
 
@@ -21,8 +26,17 @@ public class FcmAsyncService {
             log.info("[로그] 메뉴 이름: {}, 성공: {}, 실패: {}", menuName, success, failure);
 
             if (failure > 0) {
-                for (SendResponse sendResponse : response.getResponses()) {
+                List<SendResponse> responses = response.getResponses();
+
+                for (int i = 0; i < responses.size(); i++) {
+                    SendResponse sendResponse = responses.get(i);
                     if (!sendResponse.isSuccessful()) {
+                        FirebaseMessagingException ex = sendResponse.getException();
+                        MessagingErrorCode errorCode = ex != null ? ex.getMessagingErrorCode() : null;
+                        if (MessagingErrorCode.UNREGISTERED.equals(errorCode) || MessagingErrorCode.INVALID_ARGUMENT.equals(errorCode)) {
+                            invalidTokens.add(tokens.get(i));
+                        }
+
                         log.debug("[로그] 메뉴 이름: {}, 실패 원인: {}", menuName,
                                 sendResponse.getException() != null ? sendResponse.getException().getMessage() : "알 수 없음");
                     }
@@ -35,10 +49,11 @@ public class FcmAsyncService {
                 try {
                     Thread.sleep(1000 * 10); // 10초 정도 백오프
                 } catch (InterruptedException ignored) {}
-                sendMulticastWithRetry(message, menuName, attempt + 1);
+                sendMulticastWithRetry(message, tokens, menuName, attempt + 1);
             } else {
                 log.error("[로그] 메뉴 이름: {}, 전송 3회 실패: {}", menuName, e.getMessage());
             }
         }
+        return CompletableFuture.completedFuture(invalidTokens);
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/notification/service/FcmAsyncService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/service/FcmAsyncService.java
@@ -1,0 +1,44 @@
+package com.appcenter.BJJ.domain.notification.service;
+
+import com.google.firebase.messaging.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmAsyncService {
+
+    @Async("fcmTaskExecutor")
+    protected void sendMulticastWithRetry(MulticastMessage message, Long memberId, int attempt) {
+        try {
+            BatchResponse response = FirebaseMessaging.getInstance().sendEachForMulticast(message);
+
+            int success = response.getSuccessCount();
+            int failure = response.getFailureCount();
+            log.info("[로그] Member ID: {}, 성공: {}, 실패: {}", memberId, success, failure);
+
+            if (failure > 0) {
+                for (SendResponse sendResponse : response.getResponses()) {
+                    if (!sendResponse.isSuccessful()) {
+                        log.debug("[로그] Member ID: {}, 실패 원인: {}", memberId,
+                                sendResponse.getException() != null ? sendResponse.getException().getMessage() : "알 수 없음");
+                    }
+                }
+            }
+
+        } catch (FirebaseMessagingException e) {
+            if (attempt < 3) {
+                log.warn("[로그] Member ID: {} 전송 실패, {}번째 재시도 중...", memberId, attempt + 1);
+                try {
+                    Thread.sleep(1000 * 10); // 10초 정도 백오프
+                } catch (InterruptedException ignored) {}
+                sendMulticastWithRetry(message, memberId, attempt + 1);
+            } else {
+                log.error("[로그] Member ID: {}, 전송 3회 실패: {}", memberId, e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/domain/notification/service/FcmAsyncService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/service/FcmAsyncService.java
@@ -12,18 +12,18 @@ import org.springframework.stereotype.Service;
 public class FcmAsyncService {
 
     @Async("fcmTaskExecutor")
-    protected void sendMulticastWithRetry(MulticastMessage message, Long memberId, int attempt) {
+    protected void sendMulticastWithRetry(MulticastMessage message, String menuName, int attempt) {
         try {
             BatchResponse response = FirebaseMessaging.getInstance().sendEachForMulticast(message);
 
             int success = response.getSuccessCount();
             int failure = response.getFailureCount();
-            log.info("[로그] Member ID: {}, 성공: {}, 실패: {}", memberId, success, failure);
+            log.info("[로그] 메뉴 이름: {}, 성공: {}, 실패: {}", menuName, success, failure);
 
             if (failure > 0) {
                 for (SendResponse sendResponse : response.getResponses()) {
                     if (!sendResponse.isSuccessful()) {
-                        log.debug("[로그] Member ID: {}, 실패 원인: {}", memberId,
+                        log.debug("[로그] 메뉴 이름: {}, 실패 원인: {}", menuName,
                                 sendResponse.getException() != null ? sendResponse.getException().getMessage() : "알 수 없음");
                     }
                 }
@@ -31,13 +31,13 @@ public class FcmAsyncService {
 
         } catch (FirebaseMessagingException e) {
             if (attempt < 3) {
-                log.warn("[로그] Member ID: {} 전송 실패, {}번째 재시도 중...", memberId, attempt + 1);
+                log.warn("[로그] 메뉴 이름: {} 전송 실패, {}번째 재시도 중...", menuName, attempt + 1);
                 try {
                     Thread.sleep(1000 * 10); // 10초 정도 백오프
                 } catch (InterruptedException ignored) {}
-                sendMulticastWithRetry(message, memberId, attempt + 1);
+                sendMulticastWithRetry(message, menuName, attempt + 1);
             } else {
-                log.error("[로그] Member ID: {}, 전송 3회 실패: {}", memberId, e.getMessage());
+                log.error("[로그] 메뉴 이름: {}, 전송 3회 실패: {}", menuName, e.getMessage());
             }
         }
     }

--- a/src/main/java/com/appcenter/BJJ/domain/notification/service/FcmService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/service/FcmService.java
@@ -7,7 +7,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -17,10 +21,13 @@ public class FcmService {
     private static final int MAX_TOKENS_PER_BATCH = 500;
 
     private final FcmAsyncService fcmAsyncService;
+    private final DeviceTokenService deviceTokenService;
 
     // FCM 전송
     public void sendMessage(List<NotificationInfoDto> notificationInfos) {
         log.info("[로그] FcmService.sendMessage(), 대상 메뉴 수 = {}", notificationInfos.size());
+
+        List<CompletableFuture<List<String>>> futures = new ArrayList<>();
 
         for (NotificationInfoDto info : notificationInfos) {
             List<String> tokens = info.getFcmTokens();
@@ -32,11 +39,23 @@ public class FcmService {
                     info.getCafeteriaName(),
                     info.getCafeteriaCorner());
 
-            sendToBatchedTokens(tokens, title, body, info.getMenuName());
+            sendToBatchedTokens(tokens, title, body, info.getMenuName(), futures);
+        }
+
+        // 모든 비동기 작업 완료 후 실패 토큰 집계
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        Set<String> allInvalidTokens = futures.stream()
+                .flatMap(future -> future.join().stream())
+                .collect(Collectors.toSet());
+
+        if (!allInvalidTokens.isEmpty()) {
+            log.info("[로그] 유효하지 않은 FCM 토큰 {}개 비활성화", allInvalidTokens.size());
+            deviceTokenService.deactivateTokens(allInvalidTokens);
         }
     }
 
-    private void sendToBatchedTokens(List<String> tokens, String title, String body, String menuName) {
+    private void sendToBatchedTokens(List<String> tokens, String title, String body, String menuName, List<CompletableFuture<List<String>>> futures) {
         for (int i = 0; i < tokens.size(); i += MAX_TOKENS_PER_BATCH) {
             List<String> batchTokens = tokens.subList(i, Math.min(tokens.size(), i + MAX_TOKENS_PER_BATCH));
 
@@ -48,8 +67,7 @@ public class FcmService {
                             .build())
                     .build();
 
-            fcmAsyncService.sendMulticastWithRetry(message, menuName, 0);
-
+            futures.add(fcmAsyncService.sendMulticastWithRetry(message, batchTokens, menuName, 0));
         }
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/notification/service/FcmService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/service/FcmService.java
@@ -8,43 +8,48 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class FcmService {
 
+    private static final int MAX_TOKENS_PER_BATCH = 500;
+
     private final FcmAsyncService fcmAsyncService;
 
     // FCM 전송
-    public void sendMessage(Map<Long, List<NotificationInfoDto>> notificationInfoMap) {
-        log.info("[로그] FcmService.sendMessage(), 대상 회원 수 = {}", notificationInfoMap.size());
+    public void sendMessage(List<NotificationInfoDto> notificationInfos) {
+        log.info("[로그] FcmService.sendMessage(), 대상 메뉴 수 = {}", notificationInfos.size());
 
-        notificationInfoMap.forEach((memberId, infoList) -> {
-            for (NotificationInfoDto info : infoList) {
-                List<String> fcmTokens = info.getFcmTokens();
-                if (fcmTokens.isEmpty()) continue;
+        for (NotificationInfoDto info : notificationInfos) {
+            List<String> tokens = info.getFcmTokens();
+            if (tokens.isEmpty()) continue;
 
-                String title = "[밥점줘] 오늘의 메뉴 알림 \uD83C\uDF71";
-                String body = String.format("%s님이 좋아하는 '%s', 오늘 %s %s에서 제공돼요!",
-                        info.getMemberNickname(),
-                        info.getMenuName(),
-                        info.getCafeteriaName(),
-                        info.getCafeteriaCorner());
-                log.debug("[로그] 메시지: {}", body);
+            String title = "[밥점줘] 오늘의 메뉴 알림 \uD83C\uDF71";
+            String body = String.format("회원님이 좋아하는 '%s', 오늘 %s %s에서 제공돼요!",
+                    info.getMenuName(),
+                    info.getCafeteriaName(),
+                    info.getCafeteriaCorner());
 
-                MulticastMessage multicastMessage = MulticastMessage.builder()
-                        .addAllTokens(fcmTokens)
-                        .setNotification(Notification.builder()
-                                .setTitle(title)
-                                .setBody(body)
-                                .build())
-                        .build();
+            sendToBatchedTokens(tokens, title, body, info.getMenuName());
+        }
+    }
 
+    private void sendToBatchedTokens(List<String> tokens, String title, String body, String menuName) {
+        for (int i = 0; i < tokens.size(); i += MAX_TOKENS_PER_BATCH) {
+            List<String> batchTokens = tokens.subList(i, Math.min(tokens.size(), i + MAX_TOKENS_PER_BATCH));
 
-                fcmAsyncService.sendMulticastWithRetry(multicastMessage, memberId, 0);
-            }
-        });
+            MulticastMessage message = MulticastMessage.builder()
+                    .addAllTokens(batchTokens)
+                    .setNotification(Notification.builder()
+                            .setTitle(title)
+                            .setBody(body)
+                            .build())
+                    .build();
+
+            fcmAsyncService.sendMulticastWithRetry(message, menuName, 0);
+
+        }
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/notification/service/FcmService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/service/FcmService.java
@@ -1,0 +1,50 @@
+package com.appcenter.BJJ.domain.notification.service;
+
+import com.appcenter.BJJ.domain.notification.dto.NotificationInfoDto;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmService {
+
+    private final FcmAsyncService fcmAsyncService;
+
+    // FCM 전송
+    public void sendMessage(Map<Long, List<NotificationInfoDto>> notificationInfoMap) {
+        log.info("[로그] FcmService.sendMessage(), 대상 회원 수 = {}", notificationInfoMap.size());
+
+        notificationInfoMap.forEach((memberId, infoList) -> {
+            for (NotificationInfoDto info : infoList) {
+                List<String> fcmTokens = info.getFcmTokens();
+                if (fcmTokens.isEmpty()) continue;
+
+                String title = "[밥점줘] 오늘의 메뉴 알림 \uD83C\uDF71";
+                String body = String.format("%s님이 좋아하는 '%s', 오늘 %s %s에서 제공돼요!",
+                        info.getMemberNickname(),
+                        info.getMenuName(),
+                        info.getCafeteriaName(),
+                        info.getCafeteriaCorner());
+                log.debug("[로그] 메시지: {}", body);
+
+                MulticastMessage multicastMessage = MulticastMessage.builder()
+                        .addAllTokens(fcmTokens)
+                        .setNotification(Notification.builder()
+                                .setTitle(title)
+                                .setBody(body)
+                                .build())
+                        .build();
+
+
+                fcmAsyncService.sendMulticastWithRetry(multicastMessage, memberId, 0);
+            }
+        });
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/domain/todaydiet/controller/TodayDietController.java
+++ b/src/main/java/com/appcenter/BJJ/domain/todaydiet/controller/TodayDietController.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @RestController
@@ -66,7 +65,7 @@ public class TodayDietController {
     public ResponseEntity<Void> testDietNotification() {
         log.info("[로그] POST /api/device-tokens/test/notification");
 
-        Map<Long, List<NotificationInfoDto>> notificationTargets = dietNotificationService.collectNotificationTargets(LocalDate.now());
+        List<NotificationInfoDto> notificationTargets = dietNotificationService.collectNotificationTargets(LocalDate.now());
         fcmService.sendMessage(notificationTargets);
 
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/appcenter/BJJ/domain/todaydiet/controller/TodayDietController.java
+++ b/src/main/java/com/appcenter/BJJ/domain/todaydiet/controller/TodayDietController.java
@@ -1,5 +1,8 @@
 package com.appcenter.BJJ.domain.todaydiet.controller;
 
+import com.appcenter.BJJ.domain.notification.dto.NotificationInfoDto;
+import com.appcenter.BJJ.domain.notification.service.DietNotificationService;
+import com.appcenter.BJJ.domain.notification.service.FcmService;
 import com.appcenter.BJJ.domain.todaydiet.dto.TodayDietRes;
 import com.appcenter.BJJ.domain.todaydiet.dto.TodayMenuRes;
 import com.appcenter.BJJ.domain.todaydiet.service.TodayDietService;
@@ -11,10 +14,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @RestController
@@ -24,6 +30,8 @@ import java.util.List;
 public class TodayDietController {
 
     private final TodayDietService todayDietService;
+    private final DietNotificationService dietNotificationService;
+    private final FcmService fcmService;
 
     @Operation(summary = "특정 식당에서 오늘의 식단 목록 조회",
             description = """
@@ -51,5 +59,16 @@ public class TodayDietController {
         List<TodayMenuRes> todayMainMenuList = todayDietService.findMainMenusByCafeteria(cafeteriaName);
 
         return ResponseEntity.ok(todayMainMenuList);
+    }
+
+    @PostMapping("/test/notification")
+    @Operation(summary = "[test] 오늘 식단 메뉴에 좋아요를 누른 회원에게 알림 일괄 전송")
+    public ResponseEntity<Void> testDietNotification() {
+        log.info("[로그] POST /api/device-tokens/test/notification");
+
+        Map<Long, List<NotificationInfoDto>> notificationTargets = dietNotificationService.collectNotificationTargets(LocalDate.now());
+        fcmService.sendMessage(notificationTargets);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/todaydiet/repository/TodayDietRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/todaydiet/repository/TodayDietRepository.java
@@ -58,7 +58,7 @@ public interface TodayDietRepository extends JpaRepository<TodayDiet, Long> {
     List<TodayMenuRes> findTodayMainMenusByCafeteriaName(String cafeteriaName);
 
     @Query("""
-        SELECT mp.mainMenuId
+        SELECT DISTINCT mp.mainMenuId
         FROM TodayDiet td
         JOIN MenuPair mp ON td.menuPairId = mp.id
         WHERE td.date = :date
@@ -66,9 +66,18 @@ public interface TodayDietRepository extends JpaRepository<TodayDiet, Long> {
     List<Long> findMainMenuIdsByDate(LocalDate date);
 
     @Query("""
-        SELECT mp.mainMenuId
+        SELECT DISTINCT mp.mainMenuId
         FROM TodayDiet td
         JOIN MenuPair mp ON td.menuPairId = mp.id
     """)
     List<Long> findAllMainMenuIds();
+
+    @Query("""
+        SELECT DISTINCT mp.subMenuId
+        FROM TodayDiet td
+        JOIN MenuPair mp ON td.menuPairId = mp.id
+        WHERE td.date = :date
+            AND mp.subMenuId IS NOT NULL
+    """)
+    List<Long> findSubMenuIdsByDate(LocalDate date);
 }

--- a/src/main/java/com/appcenter/BJJ/global/config/AsyncConfig.java
+++ b/src/main/java/com/appcenter/BJJ/global/config/AsyncConfig.java
@@ -21,4 +21,15 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    @Bean(name = "fcmTaskExecutor")
+    public Executor fcmTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(20);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("FCM-Async-");
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/main/java/com/appcenter/BJJ/global/config/FirebaseInitializer.java
+++ b/src/main/java/com/appcenter/BJJ/global/config/FirebaseInitializer.java
@@ -1,0 +1,41 @@
+package com.appcenter.BJJ.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+
+@Service
+public class FirebaseInitializer {
+
+    @Value("${firebase.sdk.path}")
+    private String FIREBASE_SDK_PATH;
+
+    @PostConstruct // 애플리케이션이 시작될 때 자동으로 Firebase를 초기화
+    public void initialize() {
+        System.out.println("FIREBASE_SDK_PATH = " + FIREBASE_SDK_PATH);
+        // json 파일을 저장한 위치 : (resources/)XXX-firebase-adminsdk.json
+        try (InputStream serviceAccount = getClass().getClassLoader().getResourceAsStream(FIREBASE_SDK_PATH)) {
+
+            if (serviceAccount == null) {
+                throw new FileNotFoundException("Firebase service account file not found in classpath: XXX-firebase-adminsdk.json");
+            }
+
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
### 🔅 이슈번호
close #60 

---

### ⏰ 작업한 내용
- Member에 알림 설정 기능 추가
- FCM 토큰을 관리하기 위한 DeviceToken (기기 토큰) 기능 추가
- 오늘의 식단에 나온 메뉴에 좋아요를 누른 사용자에게 FCM 알림 전송하는 기능 추가
- 알림 전송 실패한 기기 토큰 비활성화 로직 구현
- 알림 성공한 기기 토큰의 마지막 사용 시간 업데이트 로직 구현

---

### ⌛️ 스크린샷 (Optional)

![image](https://github.com/user-attachments/assets/01dae37a-14c4-4316-b183-069db91dbc6f)
<i>알림 설정 토글 api</i>

![image](https://github.com/user-attachments/assets/467ee00b-e0d3-4346-b5bc-4f6df0d13ab2)
<i>FCM 기기 토큰 등록 api</i>

![image](https://github.com/user-attachments/assets/17ae9555-4d26-4e76-9491-1dbf3b1563df)
<i>FCM 알림 및 유효하지 않은 기기 토큰 비활성화 로그</i>
