### PR TITLE
[Refactor/#79] 리뷰 신고의 content를 여러 개 받을 수 있도록 리스트 형식으로 request 변경

### DIFF
--- a/src/main/java/com/appcenter/BJJ/domain/review/dto/ReviewReportReq.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/dto/ReviewReportReq.java
@@ -3,9 +3,11 @@ package com.appcenter.BJJ.domain.review.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 public class ReviewReportReq {
 
-    @Schema(description = "리뷰 신고 내용", example = "사진을 못 찍으셔요.")
-    private String content;
+    @Schema(description = "리뷰 신고 내용", example = "[\"메뉴와 관련없는 내용\", \"사진을 못 찍으셔요.\"]")
+    private List<String> content;
 }

--- a/src/main/java/com/appcenter/BJJ/domain/review/repository/ReviewReportRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/repository/ReviewReportRepository.java
@@ -2,13 +2,15 @@ package com.appcenter.BJJ.domain.review.repository;
 
 import com.appcenter.BJJ.domain.review.domain.ReviewReport;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReviewReportRepository extends JpaRepository<ReviewReport, Long> {
+    @Query("SELECT COUNT(DISTINCT r.reporterId) FROM ReviewReport r WHERE r.reviewId = :reviewId")
     Long countReviewReportByReviewId(Long reviewId);
 
     void deleteReviewReportsByReviewId(Long reviewId);
 
-    boolean existsByIdAndReporterId(Long id, Long reporterId);
+    boolean existsByReviewIdAndReporterId(Long reviewId, Long reporterId);
 }


### PR DESCRIPTION
### 🔅 이슈번호
close #79

---

### ⏰ 작업한 내용
- 리뷰 신고시 여러 개의 신고 내용이 들어갈 수 있도록 신고 request dto 변경
- 여러 개를 하나씩 데이터베이스에 저장하므로 reviewId과 reviewerId 쌍이 중복돼서 저장돼 있음 => 중복된 것을 처리해 review에 대한 report 개수가 세어지도록 reposiroty에 query문 작성

---

### ⌛️ 스크린샷 (Optional)
![image](https://github.com/user-attachments/assets/0f40b20c-ffa1-4801-9944-76f8386bf8a3)
<i>리뷰 신고 API</i>
