### PR TITLE
[Feat/#88] TaskScheduler를 이용해 뽑기 아이템 관리하기

### DIFF
--- a/src/main/java/com/appcenter/BJJ/domain/item/controller/ItemController.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/controller/ItemController.java
@@ -3,6 +3,7 @@ package com.appcenter.BJJ.domain.item.controller;
 import com.appcenter.BJJ.domain.item.dto.DetailItemRes;
 import com.appcenter.BJJ.domain.item.dto.MyItemRes;
 import com.appcenter.BJJ.domain.item.enums.ItemType;
+import com.appcenter.BJJ.domain.item.service.InventoryService;
 import com.appcenter.BJJ.domain.item.service.ItemService;
 import com.appcenter.BJJ.global.jwt.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,13 +20,13 @@ import java.util.List;
 @RequiredArgsConstructor
 @Tag(name = "Item", description = "아이템 API")
 public class ItemController {
-
     private final ItemService itemService;
+    private final InventoryService inventoryService;
 
     @Operation(summary = "마이페이지 아이템 조회")
     @GetMapping("/my")
     public ResponseEntity<MyItemRes> getMyItem(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return ResponseEntity.ok(itemService.getMyItem(userDetails.getMember().getId()));
+        return ResponseEntity.ok(inventoryService.getMyItem(userDetails.getMember().getId()));
     }
 
     @Operation(summary = "아이템 뽑기")
@@ -49,6 +50,6 @@ public class ItemController {
     @Operation(summary = "아이템 착용", description = "기본아이템의 경우, dto의 모든 필드 값 == null")
     @PatchMapping("/{itemIdx}")
     public void updateIsWearing(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestParam ItemType itemType, @PathVariable int itemIdx) {
-        itemService.toggleIsWearing(userDetails.getMember().getId(), itemType, itemIdx);
+        inventoryService.toggleIsWearing(userDetails.getMember().getId(), itemType, itemIdx);
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/item/domain/Inventory.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/domain/Inventory.java
@@ -29,20 +29,21 @@ public class Inventory {
 
     private Boolean isOwned;
 
-    private LocalDateTime validPeriod;
+    private LocalDateTime expiresAt;
 
     @Builder
-    private Inventory(Long memberId, int itemIdx, ItemType itemType, boolean isWearing, boolean isOwned, LocalDateTime validPeriod) {
+    private Inventory(Long memberId, int itemIdx, ItemType itemType, boolean isWearing, boolean isOwned, LocalDateTime expiresAt) {
         this.memberId = memberId;
         this.itemIdx = itemIdx;
         this.itemType = itemType;
         this.isOwned = isOwned;
         this.isWearing = isWearing;
-        this.validPeriod = validPeriod;
+        this.expiresAt = expiresAt;
     }
 
     public void updateValidPeriodAndIsOwned(LocalDateTime validPeriod) {
-        this.validPeriod = validPeriod.plusDays(7);
+//        this.expiresAt = validPeriod.plusDays(7); TODO 프론트 테스트를 위해 잠시 15초로 변경
+        this.expiresAt = validPeriod.plusSeconds(20);
         this.isOwned = true;
     }
 

--- a/src/main/java/com/appcenter/BJJ/domain/item/dto/DetailItemRes.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/dto/DetailItemRes.java
@@ -11,16 +11,16 @@ import java.time.LocalDateTime;
 @SuperBuilder
 public class DetailItemRes extends ItemRes {
 
-    private LocalDateTime validPeriod;
+    private LocalDateTime expiresAt;
 
     private Boolean isWearing;
 
     private Boolean isOwned;
 
     public DetailItemRes(int itemIdx, String itemName, ItemType itemType, ItemLevel itemLevel,
-                         LocalDateTime validPeriod, boolean isWearing, boolean isOwned) {
+                         LocalDateTime expiresAt, boolean isWearing, boolean isOwned) {
         super(itemIdx, itemName, itemType, itemLevel);
-        this.validPeriod = validPeriod;
+        this.expiresAt = expiresAt;
         this.isWearing = isWearing;
         this.isOwned = isOwned;
     }

--- a/src/main/java/com/appcenter/BJJ/domain/item/repository/InventoryRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/repository/InventoryRepository.java
@@ -4,8 +4,10 @@ import com.appcenter.BJJ.domain.item.domain.Inventory;
 import com.appcenter.BJJ.domain.item.dto.MyItemRes;
 import com.appcenter.BJJ.domain.item.enums.ItemType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -56,4 +58,8 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
             AND item.itemType = :itemType
             """)
     boolean existsWearingItemByMemberIdAndItemType(Long memberId, ItemType itemType);
+
+    @Modifying
+    @Transactional
+    void deleteByMemberIdAndItemIdxAndItemType(Long memberId, Integer itemIdx, ItemType itemType);
 }

--- a/src/main/java/com/appcenter/BJJ/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/repository/ItemRepository.java
@@ -24,7 +24,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
             item.itemName,
             item.itemType,
             item.itemLevel,
-            inven.validPeriod,
+            inven.expiresAt,
             coalesce(inven.isWearing, false),
             coalesce(inven.isOwned, false)
             )
@@ -41,7 +41,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
             item.itemName,
             item.itemType,
             item.itemLevel,
-            inven.validPeriod,
+            inven.expiresAt,
             coalesce(inven.isWearing, false),
             coalesce(inven.isOwned, false))
             FROM Item item

--- a/src/main/java/com/appcenter/BJJ/domain/item/schedule/ItemSchedulerService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/schedule/ItemSchedulerService.java
@@ -1,0 +1,58 @@
+package com.appcenter.BJJ.domain.item.schedule;
+
+import com.appcenter.BJJ.domain.item.enums.ItemType;
+import com.appcenter.BJJ.domain.item.repository.InventoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ItemSchedulerService {
+    @Qualifier("taskScheduler")
+    private final TaskScheduler taskScheduler;
+    private final ItemTaskRepository itemTaskRepository;
+    private final InventoryRepository inventoryRepository;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void initTask() { //Scheduler의 task는 메모리에 있어서 서버 재실행시 모두 날라감 => 재실행시 init해주기 (db조회를 통해)
+        List<ItemTask> itemTasks = itemTaskRepository.findAllByTaskStatus(TaskStatus.PENDING);
+        for (ItemTask itemTask : itemTasks) {
+            Runnable task = getTask(itemTask);
+            if (itemTask.getExpiresAt().isAfter(LocalDateTime.now())) {
+                taskScheduler.schedule(task, Instant.from(itemTask.getExpiresAt()));
+            } else {
+                taskScheduler.schedule(task, Instant.now()); //현재보다 전 => 지금 바로 스케줄러 시작
+            }
+        }
+    }
+
+    public void addOrUpdateTask(Long memberId, Integer itemIdx, ItemType itemType, LocalDateTime expiresAt) {
+        ItemTask itemTask = itemTaskRepository.findByMemberIdAndItemIdxAndItemType(memberId, itemIdx, itemType).orElseGet(
+                () -> ItemTask.create(memberId, itemIdx, itemType, expiresAt)
+        );
+        itemTask.updateExpiresAt(expiresAt);
+        itemTask.updateTaskStatue(TaskStatus.PENDING);
+
+        Runnable task = getTask(itemTask);
+        ZoneId zoneId = ZoneId.of("Asia/Seoul");
+        taskScheduler.schedule(task, itemTask.getExpiresAt().atZone(zoneId).toInstant());
+        itemTaskRepository.save(itemTask);
+    }
+
+    private Runnable getTask(ItemTask itemTask) {
+        return () -> {
+            inventoryRepository.deleteByMemberIdAndItemIdxAndItemType(itemTask.getMemberId(), itemTask.getItemIdx(), itemTask.getItemType());
+            itemTask.updateTaskStatue(TaskStatus.COMPLETE);
+            itemTaskRepository.save(itemTask); //Runnable가 실행되면 영속성 컨텍스트가 사라짐 => itemTask는 detached 상태라 수동 저장해야 함
+        };
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/domain/item/schedule/ItemTask.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/schedule/ItemTask.java
@@ -1,0 +1,57 @@
+package com.appcenter.BJJ.domain.item.schedule;
+
+import com.appcenter.BJJ.domain.item.enums.ItemType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "item_task_tb")
+public class ItemTask {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+
+    private Integer itemIdx;
+
+    @Enumerated(EnumType.STRING)
+    private ItemType itemType;
+
+    private LocalDateTime expiresAt;
+
+    @Enumerated(EnumType.STRING)
+    private TaskStatus taskStatus;
+
+    @Builder
+    private ItemTask(Long memberId, Integer itemIdx, ItemType itemType, LocalDateTime expiresAt, TaskStatus taskStatus) {
+        this.memberId = memberId;
+        this.itemIdx = itemIdx;
+        this.itemType = itemType;
+        this.expiresAt = expiresAt;
+        this.taskStatus = taskStatus;
+    }
+
+    public static ItemTask create(Long memberId, Integer itemIdx, ItemType itemType, LocalDateTime expiresAt) {
+        return ItemTask.builder()
+                .memberId(memberId)
+                .itemIdx(itemIdx)
+                .itemType(itemType)
+                .expiresAt(expiresAt)
+                .taskStatus(TaskStatus.PENDING)
+                .build();
+    }
+
+    public void updateTaskStatue(TaskStatus taskStatus){
+        this.taskStatus = taskStatus;
+    }
+
+    public void updateExpiresAt(LocalDateTime expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/domain/item/schedule/ItemTask.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/schedule/ItemTask.java
@@ -28,7 +28,7 @@ public class ItemTask {
     @Enumerated(EnumType.STRING)
     private TaskStatus taskStatus;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private ItemTask(Long memberId, Integer itemIdx, ItemType itemType, LocalDateTime expiresAt, TaskStatus taskStatus) {
         this.memberId = memberId;
         this.itemIdx = itemIdx;
@@ -47,7 +47,7 @@ public class ItemTask {
                 .build();
     }
 
-    public void updateTaskStatue(TaskStatus taskStatus){
+    public void updateTaskStatue(TaskStatus taskStatus) {
         this.taskStatus = taskStatus;
     }
 

--- a/src/main/java/com/appcenter/BJJ/domain/item/schedule/ItemTaskRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/schedule/ItemTaskRepository.java
@@ -1,0 +1,20 @@
+package com.appcenter.BJJ.domain.item.schedule;
+
+import com.appcenter.BJJ.domain.item.enums.ItemType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ItemTaskRepository extends JpaRepository<ItemTask, Long> {
+
+    @Query("""
+            SELECT task
+            FROM ItemTask task
+            WHERE task.taskStatus = :taskStatus
+            """)
+    List<ItemTask> findAllByTaskStatus(TaskStatus taskStatus);
+
+    Optional<ItemTask> findByMemberIdAndItemIdxAndItemType(Long memberId, Integer ItemIdx, ItemType itemType);
+}

--- a/src/main/java/com/appcenter/BJJ/domain/item/schedule/TaskStatus.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/schedule/TaskStatus.java
@@ -1,0 +1,8 @@
+package com.appcenter.BJJ.domain.item.schedule;
+
+import lombok.Getter;
+
+@Getter
+public enum TaskStatus {
+    PENDING, COMPLETE
+}

--- a/src/main/java/com/appcenter/BJJ/domain/item/service/InventoryService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/service/InventoryService.java
@@ -1,0 +1,52 @@
+package com.appcenter.BJJ.domain.item.service;
+
+import com.appcenter.BJJ.domain.item.domain.Inventory;
+import com.appcenter.BJJ.domain.item.dto.MyItemRes;
+import com.appcenter.BJJ.domain.item.enums.ItemType;
+import com.appcenter.BJJ.domain.item.repository.InventoryRepository;
+import com.appcenter.BJJ.domain.member.MemberRepository;
+import com.appcenter.BJJ.domain.member.domain.Member;
+import com.appcenter.BJJ.global.exception.CustomException;
+import com.appcenter.BJJ.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class InventoryService {
+    private final InventoryRepository inventoryRepository;
+    private final MemberRepository memberRepository;
+
+    public MyItemRes getMyItem(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+        return inventoryRepository.findMyItemResByMemberId(memberId).orElseGet(
+                //아이템이 하나도 없으면 null값 return (기본 아이템 장착)
+                () -> MyItemRes.builder()
+                        .nickname(member.getNickname())
+                        .point(member.getPoint())
+                        .build()
+        );
+    }
+
+    @Transactional
+    public void toggleIsWearing(Long memberId, ItemType itemType, Integer itemIdx) {
+        if (inventoryRepository.existsWearingItemByMemberIdAndItemType(memberId, itemType)) {
+            Inventory currentInven = inventoryRepository.findWearingItemByMemberIdAndItemType(memberId, itemType).orElseThrow(
+                    () -> new CustomException(ErrorCode.ITEM_NOT_FOUND)
+            );
+
+            //현재 아이템 착용 비활성화
+            currentInven.toggleIsWearing();
+        }
+
+        Inventory inventory = inventoryRepository.findByMemberIdAndItemTypeAndItemIdx(memberId, itemType, itemIdx).orElseThrow(
+                () -> new CustomException(ErrorCode.ITEM_NOT_FOUND)
+        );
+
+        //설정한 아이템 착용 활성화
+        inventory.toggleIsWearing();
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/global/config/SchedulerConfig.java
+++ b/src/main/java/com/appcenter/BJJ/global/config/SchedulerConfig.java
@@ -1,0 +1,18 @@
+package com.appcenter.BJJ.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulerConfig {
+    private static final int POOL_SIZE = 3;
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(POOL_SIZE);
+        scheduler.setThreadNamePrefix("Item scheduler: ");
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/global/exception/ErrorCode.java
+++ b/src/main/java/com/appcenter/BJJ/global/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     REVIEW_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "404-5", "해당 리뷰의 상세 정보를 불러올 수 없습니다."),
     CAFETERIA_NOT_FOUND(HttpStatus.NOT_FOUND, "404-6", "해당 식당이 존재하지 않습니다."),
     MENU_PAIR_NOT_FOUND(HttpStatus.NOT_FOUND, "404-7", "해당 메뉴쌍이 존재하지 않습니다."),
+    ITEM_TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "404-8", "아이템의 task가 존재하지 않습니다."),
 
 
     //409 Conflict


### PR DESCRIPTION
### 🔅 이슈번호
close #88 
~~commit 메시지의 label을 refactor로 잘못 적음~~

---

### ⏰ 작업한 내용
- Inventory Entity의 validDate 필드명을 expiresAt으로 변경 (유효기간보단 유효날짜가 더 맞는 표현이라 생각해서)
- TaskScheduler를 이용해 뽑은 아이템의 유효날짜를 관리
- Task관리를 위한 ItemTask Entity 추가
- 아이템을 뽑았을 때 : 아이템의 예약 Task 생성
- 유효시간에 도달했을 때 : Task 실행 -> inventory 삭제 -> task의 TaskStatus 업데이트 (Pendding -> Complete)
- 메모리에 예약 Task가 저장된다는 점을 고려해 서버 재실행시, DB에 저장된 Item Task를 다시 예약 또는 실행함 (서버 재실행되면 메모리 초기화됨)

---

### ⌛️ 스크린샷 (Optional)

<i>사진에 대한 설명을 작성해주세요.(이태릭체 그대로하기)</i>
