### PR TITLE
[Feat] 회원의 뽑기 기본 아이템 생성

### DIFF
--- a/src/main/java/com/appcenter/BJJ/domain/item/domain/Inventory.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/domain/Inventory.java
@@ -20,7 +20,7 @@ public class Inventory {
 
     private Long memberId;
 
-    private int itemIdx;
+    private Integer itemIdx;
 
     @Enumerated(EnumType.STRING)
     private ItemType itemType;
@@ -39,6 +39,17 @@ public class Inventory {
         this.isOwned = isOwned;
         this.isWearing = isWearing;
         this.expiresAt = expiresAt;
+    }
+
+    public static Inventory createDefault(Long memberId, ItemType itemType){
+        return Inventory.builder()
+                .memberId(memberId)
+                .itemIdx(0)
+                .itemType(itemType)
+                .isOwned(true)
+                .isWearing(true)
+                .expiresAt(LocalDateTime.of(9999, 12, 31, 23, 59, 59))
+                .build();
     }
 
     public void updateValidPeriodAndIsOwned(LocalDateTime validPeriod) {

--- a/src/main/java/com/appcenter/BJJ/domain/item/enums/ItemLevel.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/enums/ItemLevel.java
@@ -4,5 +4,5 @@ import lombok.Getter;
 
 @Getter
 public enum ItemLevel {
-    COMMON, NORMAL, RARE
+    DEFAULT, COMMON, NORMAL, RARE
 }

--- a/src/main/java/com/appcenter/BJJ/domain/item/repository/InventoryRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/repository/InventoryRepository.java
@@ -33,7 +33,7 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
             )
             FROM Inventory inven
             INNER JOIN Member member ON inven.memberId = member.id
-            INNER JOIN Item item ON inven.itemIdx = item.itemIdx
+            INNER JOIN Item item ON inven.itemIdx = item.itemIdx AND item.itemType = inven.itemType
             WHERE inven.memberId = :memberId
             AND inven.isWearing = true
             GROUP BY member.id
@@ -42,20 +42,19 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
 
     @Query("""
             SELECT inven FROM Inventory inven
-            LEFT JOIN Item item ON item.itemIdx = inven.itemIdx
             WHERE inven.memberId = :memberId
             AND inven.isWearing = true
-            AND item.itemType = :itemType
+            AND inven.isOwned = true
+            AND inven.itemType = :itemType
             """)
     Optional<Inventory> findWearingItemByMemberIdAndItemType(Long memberId, ItemType itemType);
 
     @Query("""
             SELECT COUNT(*) = 1
             FROM Inventory inven
-            LEFT JOIN Item item ON item.itemIdx = inven.itemIdx
             WHERE inven.memberId = :memberId
             AND inven.isWearing = true
-            AND item.itemType = :itemType
+            AND inven.itemType = :itemType
             """)
     boolean existsWearingItemByMemberIdAndItemType(Long memberId, ItemType itemType);
 

--- a/src/main/java/com/appcenter/BJJ/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/repository/ItemRepository.java
@@ -29,7 +29,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
             coalesce(inven.isOwned, false)
             )
             From Item item
-            LEFT JOIN Inventory inven ON item.itemIdx = inven.itemIdx
+            LEFT JOIN Inventory inven ON item.itemIdx = inven.itemIdx AND inven.itemType = :itemType
             AND inven.memberId = :memberId
             WHERE item.itemType = :itemType
             """)
@@ -45,7 +45,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
             coalesce(inven.isWearing, false),
             coalesce(inven.isOwned, false))
             FROM Item item
-            LEFT JOIN Inventory inven ON inven.itemIdx = :itemIdx
+            LEFT JOIN Inventory inven ON inven.itemIdx = :itemIdx AND inven.itemType = :itemType
             AND inven.memberId = :memberId
             WHERE item.itemIdx = :itemIdx
             AND item.itemType = :itemType

--- a/src/main/java/com/appcenter/BJJ/domain/item/service/InventoryService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/service/InventoryService.java
@@ -4,8 +4,6 @@ import com.appcenter.BJJ.domain.item.domain.Inventory;
 import com.appcenter.BJJ.domain.item.dto.MyItemRes;
 import com.appcenter.BJJ.domain.item.enums.ItemType;
 import com.appcenter.BJJ.domain.item.repository.InventoryRepository;
-import com.appcenter.BJJ.domain.member.MemberRepository;
-import com.appcenter.BJJ.domain.member.domain.Member;
 import com.appcenter.BJJ.global.exception.CustomException;
 import com.appcenter.BJJ.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -16,18 +14,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class InventoryService {
     private final InventoryRepository inventoryRepository;
-    private final MemberRepository memberRepository;
 
     public MyItemRes getMyItem(Long memberId) {
-        Member member = memberRepository.findById(memberId).orElseThrow(
-                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
-        );
-        return inventoryRepository.findMyItemResByMemberId(memberId).orElseGet(
-                //아이템이 하나도 없으면 null값 return (기본 아이템 장착)
-                () -> MyItemRes.builder()
-                        .nickname(member.getNickname())
-                        .point(member.getPoint())
-                        .build()
+        return inventoryRepository.findMyItemResByMemberId(memberId).orElseThrow(
+                () -> new CustomException(ErrorCode.ITEM_NOT_FOUND)
         );
     }
 
@@ -37,7 +27,6 @@ public class InventoryService {
             Inventory currentInven = inventoryRepository.findWearingItemByMemberIdAndItemType(memberId, itemType).orElseThrow(
                     () -> new CustomException(ErrorCode.ITEM_NOT_FOUND)
             );
-
             //현재 아이템 착용 비활성화
             currentInven.toggleIsWearing();
         }


### PR DESCRIPTION
### 🔅 이슈번호
close #92

---

### ⏰ 작업한 내용
- 회원 생성시, 기본 아이템 자동 지급
- 기본 아이템 제외 회원이 가진 아이템이 아무것도 없다면, 기본 아이템을 wearing 하도록 task에 추가
- inventory에서 아이템 조회시, 필요없는 join 제외 + 쿼리 조건으로 itemType을 정확하게 작성하지 않아 제대로 값이 나오지 않는 오류 수정

---

### ⌛️ 스크린샷 (Optional)

<i>사진에 대한 설명을 작성해주세요.(이태릭체 그대로하기)</i>
