### PR TITLE
[Feat/#97] 모니터링 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,9 @@ dependencies {
 	// Monitoring
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+
+	// AOP
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,10 @@ dependencies {
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 	testAnnotationProcessor "io.github.openfeign.querydsl:querydsl-apt:${querydslVersion}:jpa"
 	testAnnotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+	// Monitoring
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 dependencyManagement {

--- a/src/main/java/com/appcenter/BJJ/global/config/LoggingAspect.java
+++ b/src/main/java/com/appcenter/BJJ/global/config/LoggingAspect.java
@@ -1,0 +1,178 @@
+package com.appcenter.BJJ.global.config;
+
+import com.appcenter.BJJ.global.exception.CustomException;
+import com.appcenter.BJJ.global.jwt.UserDetailsImpl;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.minidev.json.JSONObject;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.*;
+import org.slf4j.MDC;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Aspect
+@Component
+public class LoggingAspect {
+
+    // --- Pointcuts ---
+    @Pointcut("execution(* com.appcenter.BJJ..*.*(..)) && !execution(* com.appcenter.BJJ.global..*(..))")
+    public void all() {
+    }
+
+    @Pointcut("all() && !controller()")
+    public void allExceptController() {
+    }
+
+    @Pointcut("execution(* com.appcenter.BJJ..*Controller.*(..))")
+    public void controller() {
+    }
+
+    private String getTraceId() {
+        return MDC.get("traceId");
+    }
+
+    // --- 요청 정보 DTO ---
+    @Getter
+    @AllArgsConstructor
+    private static class RequestInfo {
+        private String traceId;
+        private String memberId;
+        private String uri;
+        private String httpMethod;
+        private String controllerName;
+        private String methodName;
+        private JSONObject params;
+    }
+
+    private RequestInfo extractRequestInfo(JoinPoint joinPoint) {
+        RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
+        if (!(attributes instanceof ServletRequestAttributes servletAttributes)) {
+            return null;
+        }
+        HttpServletRequest request = servletAttributes.getRequest();
+
+        String traceId = getTraceId();
+        String memberId = getMemberIdFromSecurityContext();
+        String uri = URLDecoder.decode(request.getRequestURI(), StandardCharsets.UTF_8);
+        String httpMethod = request.getMethod();
+        String controllerName = joinPoint.getSignature().getDeclaringType().getSimpleName();
+        String methodName = joinPoint.getSignature().getName();
+        JSONObject params = getParams(request);
+
+        return new RequestInfo(traceId, memberId, uri, httpMethod, controllerName, methodName, params);
+    }
+
+    // --- 컨트롤러 Before 로그 ---
+    @Before("controller()")
+    public void logRequestStart(JoinPoint joinPoint) {
+        RequestInfo info = extractRequestInfo(joinPoint);
+        if (info == null) return;
+
+        log.info("LOG_TYPE=HTTP_REQUEST | EVENT=START | TRACE_ID={} | MEMBER_ID={} | URI={} | HTTP_METHOD={} | HANDLER={}.{} | PARAMS={}",
+                info.getTraceId(), info.getMemberId(), info.getUri(), info.getHttpMethod(),
+                info.getControllerName(), info.getMethodName(), info.getParams());
+    }
+
+    // --- 컨트롤러 정상 종료 로그 ---
+    @AfterReturning(pointcut = "controller()", returning = "result")
+    public void logRequestEnd(JoinPoint joinPoint, Object result) {
+        RequestInfo info = extractRequestInfo(joinPoint);
+        if (info == null) return;
+
+        log.info("LOG_TYPE=HTTP_REQUEST | EVENT=END | TRACE_ID={} | MEMBER_ID={} | URI={} | HANDLER={}.{} | STATUS=SUCCESS",
+                info.getTraceId(), info.getMemberId(), info.getUri(),
+                info.getControllerName(), info.getMethodName());
+    }
+
+    // --- 컨트롤러 예외 로그 ---
+    @AfterThrowing(pointcut = "controller()", throwing = "ex")
+    public void logRequestError(JoinPoint joinPoint, Throwable ex) {
+        RequestInfo info = extractRequestInfo(joinPoint);
+        if (info == null) return;
+
+        String template = "LOG_TYPE=HTTP_REQUEST | EVENT=ERROR | TRACE_ID={} | MEMBER_ID={} | URI={} | HANDLER={}.{} | ERROR={} | MESSAGE={}";
+
+        if (ex instanceof CustomException) {
+            log.info(template, info.getTraceId(), info.getMemberId(), info.getUri(),
+                    info.getControllerName(), info.getMethodName(),
+                    ex.getClass().getSimpleName(), ex.getMessage());
+        } else {
+            log.error(template, info.getTraceId(), info.getMemberId(), info.getUri(),
+                    info.getControllerName(), info.getMethodName(),
+                    ex.getClass().getSimpleName(), ex.getMessage());
+        }
+    }
+
+    // --- 파라미터 로깅 (컨트롤러 제외) ---
+    @Before("allExceptController()")
+    public void logParameters(JoinPoint joinPoint) {
+        String traceId = getTraceId();
+        String className = joinPoint.getSignature().getDeclaringTypeName();
+        String methodName = joinPoint.getSignature().getName();
+        Object[] args = joinPoint.getArgs();
+        String params = Arrays.stream(args)
+                .map(arg -> arg != null ? arg.toString() : "null")
+                .collect(Collectors.joining(", "));
+
+        log.debug("LOG_TYPE=METHOD | EVENT=CALL | TRACE_ID={} | SIGNATURE={}.{} | PARAMS=[{}]",
+                traceId, className, methodName, params);
+    }
+
+    // --- 성능 측정 (전체) ---
+    @Around("all()")
+    public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        long start = System.currentTimeMillis();
+
+        try {
+            return joinPoint.proceed();
+        } finally {
+            long elapsed = System.currentTimeMillis() - start;
+            String traceId = getTraceId();
+            String className = joinPoint.getSignature().getDeclaringTypeName();
+            String methodName = joinPoint.getSignature().getName();
+
+            log.debug("LOG_TYPE=METHOD | EVENT=PERFORMANCE | TRACE_ID={} | SIGNATURE={}.{} | EXECUTION_TIME={}ms",
+                    traceId, className, methodName, elapsed);
+        }
+    }
+
+    // --- 요청 파라미터 추출 ---
+    private JSONObject getParams(HttpServletRequest request) {
+        JSONObject jsonObject = new JSONObject();
+        Enumeration<String> params = request.getParameterNames();
+        while (params.hasMoreElements()) {
+            String param = params.nextElement();
+            jsonObject.put(param.replace(".", "-"), request.getParameter(param));
+        }
+        return jsonObject;
+    }
+
+    private String getMemberIdFromSecurityContext() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return "-";
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof UserDetailsImpl userDetails) {
+            return userDetails.getUsername();
+        }
+
+        return "-";
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/global/config/SecurityConfig.java
+++ b/src/main/java/com/appcenter/BJJ/global/config/SecurityConfig.java
@@ -25,8 +25,8 @@ import java.net.UnknownHostException;
 
 @Slf4j
 @Configuration
-@RequiredArgsConstructor
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtProvider jwtProvider;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
@@ -36,6 +36,7 @@ public class SecurityConfig {
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final AuthenticationEntryPointImpl authenticationEntryPointImpl;
     private final AccessDeniedHandlerImpl accessDeniedHandlerImpl;
+    private final TraceIdFilter traceIdFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -73,6 +74,7 @@ public class SecurityConfig {
 
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(traceIdFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new JwtFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new JwtValidateFilter(), JwtFilter.class)
                 .exceptionHandling(handling -> handling

--- a/src/main/java/com/appcenter/BJJ/global/config/TraceIdFilter.java
+++ b/src/main/java/com/appcenter/BJJ/global/config/TraceIdFilter.java
@@ -1,0 +1,29 @@
+package com.appcenter.BJJ.global.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+public class TraceIdFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String traceId = UUID.randomUUID().toString();
+        MDC.put("traceId", traceId);
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove("traceId"); // 요청 끝나면 반드시 제거
+        }
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,249 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- 현재 활성 프로필 가져오기 -->
+    <springProperty scope="context" name="spring.profile" source="spring.profiles.active" />
+    <property name="LOGBACK_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"/>
+
+    <!-- 개발 환경 설정 -->
+    <springProfile name="dev">
+        <property name="LOG_PATH" value="C:/bjj/logs" />
+
+        <!-- INFO 이상 콘솔 출력 -->
+        <appender name="DEV_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>${LOGBACK_PATTERN}</pattern>
+            </encoder>
+            <!-- INFO 레벨 이상만 필터링 -->
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>INFO</level>
+            </filter>
+        </appender>
+
+        <!-- DEBUG 레벨 콘솔 출력 -->
+        <appender name="DEV_DEBUG_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>${LOGBACK_PATTERN}</pattern>
+            </encoder>
+            <!-- DEBUG 레벨만 필터링 -->
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>DEBUG</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+        </appender>
+
+        <!-- DEBUG만 저장 -->
+        <appender name="DEV_DEBUG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_PATH}/debug.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/debug.%d{yyyy-MM-dd}.log</fileNamePattern>
+                <maxHistory>14</maxHistory>
+            </rollingPolicy>
+            <encoder>
+                <pattern>${LOGBACK_PATTERN}</pattern>
+            </encoder>
+            <!-- DEBUG 레벨만 필터링 -->
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>DEBUG</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+        </appender>
+
+        <!-- INFO만 저장 -->
+        <appender name="DEV_INFO_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_PATH}/info.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/info.%d{yyyy-MM-dd}.log</fileNamePattern>
+                <maxHistory>14</maxHistory>
+            </rollingPolicy>
+            <encoder>
+                <pattern>${LOGBACK_PATTERN}</pattern>
+            </encoder>
+            <!-- INFO 레벨만 필터링 -->
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>INFO</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+        </appender>
+
+        <!-- 패키지별 로그 레벨 설정 -->
+        <!-- sql: DEBUG 레벨 -->
+        <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
+            <appender-ref ref="DEV_CONSOLE" />
+            <appender-ref ref="DEV_DEBUG_FILE" />
+            <appender-ref ref="DEV_INFO_FILE" />
+        </logger>
+
+        <!-- security: DEBUG 레벨 -->
+        <logger name="org.springframework.security" level="DEBUG" additivity="false">
+            <appender-ref ref="DEV_CONSOLE" />
+            <appender-ref ref="DEV_DEBUG_FILE" />
+            <appender-ref ref="DEV_INFO_FILE" />
+        </logger>
+
+        <!-- BJJ: DEBUG 레벨 -->
+        <logger name="com.appcenter.BJJ" level="DEBUG" additivity="false">
+            <appender-ref ref="DEV_CONSOLE" />
+            <appender-ref ref="DEV_DEBUG_CONSOLE" />
+            <appender-ref ref="DEV_DEBUG_FILE" />
+            <appender-ref ref="DEV_INFO_FILE" />
+        </logger>
+
+        <!-- AnonymousAuthenticationFilter: INFO 레벨 -->
+        <logger name="org.springframework.security.web.authentication.AnonymousAuthenticationFilter"
+                level="INFO" additivity="false">
+            <appender-ref ref="DEV_CONSOLE" />
+            <appender-ref ref="DEV_DEBUG_FILE" />
+            <appender-ref ref="DEV_INFO_FILE" />
+        </logger>
+
+        <!-- FilterChainProxy: INFO 레벨 -->
+        <logger name="org.springframework.security.web.FilterChainProxy"
+                level="INFO" additivity="false">
+            <appender-ref ref="DEV_CONSOLE" />
+            <appender-ref ref="DEV_DEBUG_FILE" />
+            <appender-ref ref="DEV_INFO_FILE" />
+        </logger>
+
+        <!-- 루트: INFO 레벨 -->
+        <root level="INFO">
+            <appender-ref ref="DEV_CONSOLE" />
+            <appender-ref ref="DEV_DEBUG_FILE" />
+            <appender-ref ref="DEV_INFO_FILE" />
+        </root>
+    </springProfile>
+
+    <!-- 운영 환경 설정 -->
+    <springProfile name="prod">
+        <property name="LOG_PATH" value="/logs" />
+
+        <!-- DEBUG만 저장 (트러블슈팅용) -->
+        <appender name="PROD_DEBUG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_PATH}/debug.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/debug.%d{yyyy-MM-dd}.log</fileNamePattern>
+                <maxHistory>7</maxHistory>
+            </rollingPolicy>
+            <encoder>
+                <pattern>${LOGBACK_PATTERN}</pattern>
+            </encoder>
+            <!-- DEBUG 레벨만 필터링 -->
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>DEBUG</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+        </appender>
+
+        <!-- INFO만 저장 (서비스 흐름 추적용) -->
+        <appender name="PROD_INFO_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_PATH}/info.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/info.%d{yyyy-MM-dd}.log</fileNamePattern>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+            <encoder>
+                <pattern>${LOGBACK_PATTERN}</pattern>
+            </encoder>
+            <!-- INFO 레벨만 필터링 -->
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>INFO</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+        </appender>
+
+        <!-- WARN만 저장 (이상 징후 파악용) -->
+        <appender name="PROD_WARN_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_PATH}/warn.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/warn.%d{yyyy-MM-dd}.log</fileNamePattern>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+            <encoder>
+                <pattern>${LOGBACK_PATTERN}</pattern>
+            </encoder>
+            <!-- WARN 레벨만 필터링 -->
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>WARN</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+        </appender>
+
+
+        <!-- ERROR만 저장 (중요 문제점 추적용) -->
+        <appender name="PROD_ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_PATH}/error.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/error.%d{yyyy-MM-dd}.log</fileNamePattern>
+                <maxHistory>30</maxHistory>
+            </rollingPolicy>
+            <encoder>
+                <pattern>${LOGBACK_PATTERN}</pattern>
+            </encoder>
+            <!-- ERROR 레벨만 필터링 -->
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>ERROR</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
+        </appender>
+
+        <!-- 패키지별 로그 레벨 설정 -->
+        <!-- sql: DEBUG 레벨 -->
+        <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
+            <appender-ref ref="PROD_DEBUG_FILE"/>
+            <appender-ref ref="PROD_INFO_FILE" />
+            <appender-ref ref="PROD_WARN_FILE" />
+            <appender-ref ref="PROD_ERROR_FILE" />
+        </logger>
+
+        <!-- security: DEBUG 레벨 -->
+        <logger name="org.springframework.security" level="DEBUG" additivity="false">
+            <appender-ref ref="PROD_DEBUG_FILE" />
+            <appender-ref ref="PROD_INFO_FILE" />
+            <appender-ref ref="PROD_WARN_FILE" />
+            <appender-ref ref="PROD_ERROR_FILE" />
+        </logger>
+
+        <!-- BJJ: DEBUG 레벨 -->
+        <logger name="com.appcenter.BJJ" level="DEBUG" additivity="false">
+            <appender-ref ref="PROD_DEBUG_FILE" />
+            <appender-ref ref="PROD_INFO_FILE" />
+            <appender-ref ref="PROD_WARN_FILE" />
+            <appender-ref ref="PROD_ERROR_FILE" />
+        </logger>
+
+        <!-- AnonymousAuthenticationFilter: INFO 레벨 -->
+        <logger name="org.springframework.security.web.authentication.AnonymousAuthenticationFilter"
+                level="INFO" additivity="false">
+            <appender-ref ref="PROD_DEBUG_FILE" />
+            <appender-ref ref="PROD_INFO_FILE" />
+            <appender-ref ref="PROD_WARN_FILE" />
+            <appender-ref ref="PROD_ERROR_FILE" />
+        </logger>
+
+        <!-- AnonymousAuthenticationFilter: INFO 레벨 -->
+        <logger name="org.springframework.security.web.FilterChainProxy"
+                level="INFO" additivity="false">
+            <appender-ref ref="PROD_DEBUG_FILE" />
+            <appender-ref ref="PROD_INFO_FILE" />
+            <appender-ref ref="PROD_WARN_FILE" />
+            <appender-ref ref="PROD_ERROR_FILE" />
+        </logger>
+
+        <!-- 루트: INFO 레벨 -->
+        <root level="INFO">
+            <appender-ref ref="PROD_DEBUG_FILE" />
+            <appender-ref ref="PROD_INFO_FILE" />
+            <appender-ref ref="PROD_WARN_FILE" />
+            <appender-ref ref="PROD_ERROR_FILE" />
+        </root>
+
+    </springProfile>
+
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -3,7 +3,7 @@
 
     <!-- 현재 활성 프로필 가져오기 -->
     <springProperty scope="context" name="spring.profile" source="spring.profiles.active" />
-    <property name="LOGBACK_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"/>
+    <property name="LOGBACK_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{traceId}] - %msg%n"/>
 
     <!-- 개발 환경 설정 -->
     <springProfile name="dev">


### PR DESCRIPTION
### 🔅 이슈번호
close #97 

---

### ⏰ 작업한 내용
#### 1. 로그 시스템 커스터마이징
- Logback 설정 수정  
  - 지정한 로그 레벨별로 로그가 각각 다른 파일에 저장되도록 구성

#### 2. 로그·메트릭 데이터 수집 및 시각화 인프라 구성
- Docker Compose를 활용해 Promtail, Loki, Prometheus, Grafana 컨테이너 환경 구축  
- Promtail: 파일 기반 로그 수집  
- Loki: 로그 저장 및 관리  
- Prometheus: 메트릭 데이터 수집·저장·조회
- Grafana: Loki 및 Prometheus 데이터 기반 대시보드 시각화

#### 3. Spring Boot 메트릭 연동
- Spring Boot Actuator 및 Micrometer 의존성 추가 및 설정
- Prometheus와 연동해 메트릭 수집 기능 구현

#### 4. AOP 기반 로깅 기능 구현
- `TraceIdFilter` 추가  
  - 요청별로 UUID 기반 TraceId를 MDC에 저장하여 로그 추적을 용이하게 함
- 로그 포맷 개선
  - 모든 로그에 TraceId 포함  
  - 타임스탬프에 밀리초 단위 포함 
- 각 메서드 시작 시 로깅 추가
  - 컨트롤러 요청 처리 로그
    - 요청 시작: HTTP 메서드, URI, 핸들러명, 파라미터 INFO 레벨 출력
    - 정상 종료: 성공 상태 INFO 레벨 출력
    - 예외 발생 시  
      - `CustomException`: 예외 메시지 INFO 레벨 출력  
      - 기타 예외: 예외 메시지 ERROR 레벨 출력 
  - 컨트롤러 제외 메서드 
    - 메서드 시그니처 및 파라미터 DEBUG 레벨 출력
  - 모든 메서드의 실행 시간 DEBUG 레벨로 출력

---

### ⌛️ 스크린샷 (Optional)

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/9133175d-de39-411c-a5fa-926e1f32839b" />
<i>Grafana 대시보드 (서버)</i>

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/f7d48175-9d50-4f91-a664-4f930b24d2f9" />
<i>Grafana 대시보드 (로컬)</i>



