### PR TITLE
[Fix] GitHub Actions 워크플로 수정

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -22,9 +22,8 @@ jobs:
       - name: make application.properties
         if: contains(github.ref, 'main')
         run: |
-          mkdir ./src/main/resources
+          mkdir -p ./src/main/resources
           cd ./src/main/resources
-          touch ./application.properties
           echo "${{ secrets.APPLICATION }}" > ./application.properties # github actions에서 설정한 값을 application.properties 파일에 쓰기
 
       # gradle build


### PR DESCRIPTION
### 🔅 이슈번호
close #97

---

### ⏰ 작업한 내용
- src/main/resources 디렉토리에 이미 logback-spring.xml 파일이 존재하여 디렉토리 중복 생성 오류가 발생할 수 있어 mkdir -p 옵션 적용
- echo 명령어로 파일을 생성하므로 중복되는 touch 명령 제거

---

### ⌛️ 스크린샷 (Optional)

<i>사진에 대한 설명을 작성해주세요.(이태릭체 그대로하기)</i>
