### PR TITLE
[Fix] 콘솔 로그 설정 추가로 스프링 예외 종료 시 로그 미출력 문제 해결

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -120,6 +120,16 @@
     <springProfile name="prod">
         <property name="LOG_PATH" value="/logs" />
 
+        <!-- INFO 이상 콘솔 출력 -->
+        <appender name="PROD_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>${LOGBACK_PATTERN}</pattern>
+            </encoder>
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>INFO</level>
+            </filter>
+        </appender>
+
         <!-- DEBUG만 저장 (트러블슈팅용) -->
         <appender name="PROD_DEBUG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
             <file>${LOG_PATH}/debug.log</file>
@@ -196,6 +206,7 @@
         <!-- 패키지별 로그 레벨 설정 -->
         <!-- sql: DEBUG 레벨 -->
         <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
+            <appender-ref ref="PROD_CONSOLE" />
             <appender-ref ref="PROD_DEBUG_FILE"/>
             <appender-ref ref="PROD_INFO_FILE" />
             <appender-ref ref="PROD_WARN_FILE" />
@@ -204,6 +215,7 @@
 
         <!-- security: DEBUG 레벨 -->
         <logger name="org.springframework.security" level="DEBUG" additivity="false">
+            <appender-ref ref="PROD_CONSOLE" />
             <appender-ref ref="PROD_DEBUG_FILE" />
             <appender-ref ref="PROD_INFO_FILE" />
             <appender-ref ref="PROD_WARN_FILE" />
@@ -212,6 +224,7 @@
 
         <!-- BJJ: DEBUG 레벨 -->
         <logger name="com.appcenter.BJJ" level="DEBUG" additivity="false">
+            <appender-ref ref="PROD_CONSOLE" />
             <appender-ref ref="PROD_DEBUG_FILE" />
             <appender-ref ref="PROD_INFO_FILE" />
             <appender-ref ref="PROD_WARN_FILE" />
@@ -221,6 +234,7 @@
         <!-- AnonymousAuthenticationFilter: INFO 레벨 -->
         <logger name="org.springframework.security.web.authentication.AnonymousAuthenticationFilter"
                 level="INFO" additivity="false">
+            <appender-ref ref="PROD_CONSOLE" />
             <appender-ref ref="PROD_DEBUG_FILE" />
             <appender-ref ref="PROD_INFO_FILE" />
             <appender-ref ref="PROD_WARN_FILE" />
@@ -230,6 +244,7 @@
         <!-- AnonymousAuthenticationFilter: INFO 레벨 -->
         <logger name="org.springframework.security.web.FilterChainProxy"
                 level="INFO" additivity="false">
+            <appender-ref ref="PROD_CONSOLE" />
             <appender-ref ref="PROD_DEBUG_FILE" />
             <appender-ref ref="PROD_INFO_FILE" />
             <appender-ref ref="PROD_WARN_FILE" />
@@ -238,6 +253,7 @@
 
         <!-- 루트: INFO 레벨 -->
         <root level="INFO">
+            <appender-ref ref="PROD_CONSOLE" />
             <appender-ref ref="PROD_DEBUG_FILE" />
             <appender-ref ref="PROD_INFO_FILE" />
             <appender-ref ref="PROD_WARN_FILE" />


### PR DESCRIPTION
### 🔅 이슈번호
close #97 

---

### ⏰ 작업한 내용
- 운영 환경에서 서버가 예외로 종료될 때 로그 파일이 생성되지 않아 원인 파악이 어려운 문제가 발생
- logback 설정에 콘솔 로그 출력을 추가하여, 파일 로그가 남지 않더라도 콘솔에서 예외 로그 확인이 가능하도록 개선

---

### ⌛️ 스크린샷 (Optional)

<i>사진에 대한 설명을 작성해주세요.(이태릭체 그대로하기)</i>
