### PR TITLE
[Feat/#110] 배너 관리 및 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/appcenter/BJJ/domain/banner/Banner.java
+++ b/src/main/java/com/appcenter/BJJ/domain/banner/Banner.java
@@ -1,0 +1,42 @@
+package com.appcenter.BJJ.domain.banner;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "banner_tb")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Banner {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 배너 이미지 이름
+    private String imageName;
+
+    // 배너 페이지 URI
+    private String pageUri;
+
+    // 배너 노출 순서 (null일 경우 노출 x)
+    private Integer sortOrder;
+
+    @Builder
+    private Banner(String imageName, String pageUri, Integer sortOrder) {
+        this.imageName = imageName;
+        this.pageUri = pageUri;
+        this.sortOrder = sortOrder;
+    }
+
+    public void updatePageUri(String pageUri) {
+        this.pageUri = pageUri;
+    }
+
+    public void updateSortOrder(Integer sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/domain/banner/Banner.java
+++ b/src/main/java/com/appcenter/BJJ/domain/banner/Banner.java
@@ -32,6 +32,10 @@ public class Banner {
         this.sortOrder = sortOrder;
     }
 
+    public void updateImageName(String imageName) {
+        this.imageName = imageName;
+    }
+
     public void updatePageUri(String pageUri) {
         this.pageUri = pageUri;
     }

--- a/src/main/java/com/appcenter/BJJ/domain/banner/BannerController.java
+++ b/src/main/java/com/appcenter/BJJ/domain/banner/BannerController.java
@@ -1,0 +1,31 @@
+package com.appcenter.BJJ.domain.banner;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/banners")
+@RequiredArgsConstructor
+@Tag(name = "Banner", description = "배너 API")
+public class BannerController {
+
+    private final BannerService bannerService;
+
+    @Operation(summary = "배너 목록 조회",
+            description = """  
+                    - 배너 이미지와 페이지 URI를 반환
+                    - imageName: /images/banner/{imageName} 형식의 URI로 배너 이미지 접근 가능
+                    - pageUri: 배너 클릭 시 이동할 페이지 URI
+                    """)
+    @GetMapping
+    public ResponseEntity<List<BannerRes>> getVisibleBanners() {
+        return ResponseEntity.ok(bannerService.findVisibleBanners());
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/domain/banner/BannerManagementController.java
+++ b/src/main/java/com/appcenter/BJJ/domain/banner/BannerManagementController.java
@@ -12,7 +12,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -50,10 +49,23 @@ public class BannerManagementController {
         return ResponseEntity.ok(bannerManagementService.getBanners());
     }
 
-    @PutMapping("/{bannerId}")
+    @Operation(summary = "배너 수정",
+            description = """       
+                    - 지정한 bannerId의 배너 정보를 수정
+                    - 수정 가능 항목 (미기입 항목은 수정 X):
+                      • imageName: 배너 이미지 파일명
+                      • pageUri: 배너 클릭 시 이동할 URI
+                      • sortOrder: 배너 노출 순서
+                    - sortOrder 규칙:
+                      • 0부터 시작하는 연속된 정수로 관리
+                      • null 값은 비노출 상태를 의미
+                      • 순서 변경 시 다른 배너들의 sortOrder도 자동 조정됨
+                    """)
+    @PutMapping(value = "/{bannerId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Banner> updateBanner(
             @PathVariable Long bannerId,
-            @RequestBody BannerPut bannerPut) {
-        return ResponseEntity.ok(bannerManagementService.updateBanner(bannerId, bannerPut));
+            @RequestPart BannerPut bannerPut,
+            @RequestPart(required = false) MultipartFile imageFile) {
+        return ResponseEntity.ok(bannerManagementService.updateBanner(bannerId, bannerPut, imageFile));
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/banner/BannerManagementController.java
+++ b/src/main/java/com/appcenter/BJJ/domain/banner/BannerManagementController.java
@@ -1,0 +1,59 @@
+package com.appcenter.BJJ.domain.banner;
+
+import com.appcenter.BJJ.domain.banner.BannerReq.BannerPost;
+import com.appcenter.BJJ.domain.banner.BannerReq.BannerPut;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/banners")
+@RequiredArgsConstructor
+@Tag(name = "Banner (Admin)", description = "배너 API (관리자만 사용)")
+public class BannerManagementController {
+
+    private final BannerManagementService bannerManagementService;
+
+    @Operation(summary = "배너 저장",
+            description = """
+                    - pageUri에 배너 클릭 시 이동할 뷰 페이지의 URI를 작성
+                    - sortOrder에 희망 하는 배너 노출 순서를 작성
+                    - 배너 노출 순서는 0부터 차례대로 배정됨
+                    - 기존 배너의 sortOrder를 희망할 시 해당 배너에 희망하는 sortOrder를 배정 및 해당 순서 이후의 배너들의 sortOrder를 하나 씩 증가
+                    - sortOrder에 -1 입력 시 가장 마지막 순서에 배정
+                    - sortOrder를 입력 하지 않을 시(null), 배너를 노출하지 않음
+                    """)
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Banner> uploadBanner(
+            @Valid @RequestPart BannerPost bannerPost,
+            @RequestPart MultipartFile imageFile) {
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(bannerManagementService.uploadBanner(bannerPost, imageFile));
+    }
+
+    @Operation(summary = "모든 배너 목록 조회",
+            description = """       
+                    - sortOrder 오름차순으로 정렬되어 조회
+                    - sortOrder가 null인 배너는 가장 뒤에 배치
+                    """)
+    @GetMapping
+    public ResponseEntity<List<Banner>> getBanners() {
+        return ResponseEntity.ok(bannerManagementService.getBanners());
+    }
+
+    @PutMapping("/{bannerId}")
+    public ResponseEntity<Banner> updateBanner(
+            @PathVariable Long bannerId,
+            @RequestBody BannerPut bannerPut) {
+        return ResponseEntity.ok(bannerManagementService.updateBanner(bannerId, bannerPut));
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/domain/banner/BannerManagementService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/banner/BannerManagementService.java
@@ -1,0 +1,149 @@
+package com.appcenter.BJJ.domain.banner;
+
+import com.appcenter.BJJ.domain.banner.BannerReq.BannerPost;
+import com.appcenter.BJJ.global.exception.CustomException;
+import com.appcenter.BJJ.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BannerManagementService {
+
+    private final BannerRepository bannerRepository;
+
+    @Value("${storage.images.banner}")
+    private String BANNER_IMG_DIR;
+
+    @Transactional
+    public Banner uploadBanner(BannerPost bannerPost, MultipartFile imageFile) {
+        Integer sortOrder = calculateSortOrder(bannerPost.getSortOrder(), null);
+
+        Banner build = Banner.builder()
+                .imageName(uploadImage(imageFile))
+                .pageUri(bannerPost.getPageUri())
+                .sortOrder(sortOrder)
+                .build();
+
+        return bannerRepository.save(build);
+    }
+
+    public List<Banner> getBanners() {
+        return bannerRepository.findAllOrderBySortOrderAscNullsLast();
+    }
+
+    @Transactional
+    public Banner updateBanner(Long bannerId, BannerReq.BannerPut bannerPut) {
+        Banner banner = bannerRepository.findById(bannerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.BANNER_NOT_FOUND));
+
+        if (bannerPut.getPageUri() != null) {
+            banner.updatePageUri(bannerPut.getPageUri());
+        }
+
+        Integer oldOrder = banner.getSortOrder();
+        Integer newOrder = calculateSortOrder(bannerPut.getSortOrder(), oldOrder);
+
+        if (!Objects.equals(newOrder, oldOrder)) {
+            banner.updateSortOrder(newOrder);
+        }
+
+        return banner;
+    }
+
+    /*
+    * 요청한 sortOrder를 계산하고, 기존 배너들의 순서를 조정
+    * @param requestedOrder - 사용자가 요청한 sortOrder (0부터 시작, -1=마지막, null=비노출)
+    * @param oldOrder      - 기존 배너의 sortOrder (신규 배너는 null)
+    * */
+    private Integer calculateSortOrder(Integer requestedOrder, Integer oldOrder) {
+
+        // 1. 비노출 배너
+        if (requestedOrder == null) {
+            if (oldOrder != null) {
+                bannerRepository.findBySortOrderGreaterThan(oldOrder)
+                        .forEach(b -> b.updateSortOrder(b.getSortOrder() - 1));
+            }
+            return null;
+        }
+
+        int maxOrder = Objects.requireNonNullElse(bannerRepository.findMaxSortOrder(), -1);
+
+        // 2. 신규 배너 삽입
+        if (oldOrder == null) {
+            // requestedOrder가 -1 또는 최대값 초과인 경우 마지막 위치로
+            if (requestedOrder == -1 || requestedOrder > maxOrder) {
+                return maxOrder + 1;
+            }
+
+            // gap 없애며 삽입
+            bannerRepository.findBySortOrderGreaterThanEqual(requestedOrder)
+                    .forEach(b -> b.updateSortOrder(b.getSortOrder() + 1));
+
+            return requestedOrder;
+        }
+
+        // 3. 기존 노출 배너 이동
+        // requestedOrder 조정 (-1 또는 최대값 초과인 경우 마지막 위치로)
+        if (requestedOrder == -1 || requestedOrder > maxOrder) {
+            requestedOrder = maxOrder;
+        }
+
+        if (oldOrder < requestedOrder) {
+            bannerRepository.findBySortOrderBetween(oldOrder + 1, requestedOrder)
+                    .forEach(b -> b.updateSortOrder(b.getSortOrder() - 1));
+        } else if (oldOrder > requestedOrder) {
+            bannerRepository.findBySortOrderBetween(requestedOrder, oldOrder - 1)
+                    .forEach(b -> b.updateSortOrder(b.getSortOrder() + 1));
+        }
+
+        return requestedOrder;
+    }
+
+    /*
+    * 배너 이미지 저장
+    * */
+    private String uploadImage(MultipartFile imageFile) {
+        // 업로드할 디렉토리가 존재하는지 확인
+        File directory = new File(BANNER_IMG_DIR);
+        if (!directory.exists()) {
+            log.info("[로그] 업로드할 디렉토리가 존재하지 않음. {} 디렉토리 생성", BANNER_IMG_DIR);
+            // 디렉토리가 존재하지 않을 경우 생성
+            boolean created = directory.mkdirs(); // 부모 디렉토리도 포함하여 생성
+            if (!created) {
+                throw new RuntimeException("업로드 디렉토리를 생성할 수 없습니다: " + BANNER_IMG_DIR);
+            }
+        }
+
+        // 파일 확장자 추출
+        String originalFilename = imageFile.getOriginalFilename();
+        if (originalFilename == null || !originalFilename.contains(".")) {
+            throw new CustomException(ErrorCode.INVALID_FILE_NAME);
+        }
+        String fileExtension = Objects.requireNonNull(originalFilename).substring(originalFilename.lastIndexOf("."));
+
+        // 고유한 파일 이름 생성 (UUID 사용)
+        String uniqueFileName = UUID.randomUUID() + fileExtension;
+
+        // 파일 업로드 로직 (파일 저장 등)
+        try {
+            File destinationFile = new File(directory, uniqueFileName);
+            imageFile.transferTo(destinationFile);
+        } catch (Exception e) {
+            throw new RuntimeException("파일 업로드 중 오류 발생", e);
+        }
+
+        return uniqueFileName;
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/domain/banner/BannerRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/banner/BannerRepository.java
@@ -1,0 +1,21 @@
+package com.appcenter.BJJ.domain.banner;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface BannerRepository extends JpaRepository<Banner, Long> {
+    @Query("SELECT MAX(b.sortOrder) FROM Banner b")
+    Integer findMaxSortOrder();
+
+    @Query("SELECT b FROM Banner b ORDER BY b.sortOrder ASC NULLS LAST")
+    List<Banner> findAllOrderBySortOrderAscNullsLast();
+
+    List<Banner> findBySortOrderGreaterThan(Integer sortOrder);
+
+    List<Banner> findBySortOrderGreaterThanEqual(Integer sortOrder);
+
+    List<Banner> findBySortOrderBetween(Integer start, Integer end);
+}

--- a/src/main/java/com/appcenter/BJJ/domain/banner/BannerRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/banner/BannerRepository.java
@@ -18,4 +18,6 @@ public interface BannerRepository extends JpaRepository<Banner, Long> {
     List<Banner> findBySortOrderGreaterThanEqual(Integer sortOrder);
 
     List<Banner> findBySortOrderBetween(Integer start, Integer end);
+
+    List<Banner> findAllBySortOrderIsNotNullOrderBySortOrder();
 }

--- a/src/main/java/com/appcenter/BJJ/domain/banner/BannerReq.java
+++ b/src/main/java/com/appcenter/BJJ/domain/banner/BannerReq.java
@@ -1,0 +1,30 @@
+package com.appcenter.BJJ.domain.banner;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BannerReq {
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class BannerPost {
+        @NotBlank(message = "pageUri는 필수입니다.")
+        @Schema(description = "배너 페이지 URI", example = "/view/reviews/best?period=DAY")
+        private String pageUri;
+
+        @Schema(description = "배너 노출 순서", example = "-1")
+        private Integer sortOrder;
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class BannerPut {
+        @Schema(description = "배너 페이지 URI", example = "/view/reviews/best?period=DAY")
+        private String pageUri;
+
+        @Schema(description = "배너 노출 순서", example = "-1")
+        private Integer sortOrder;
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/domain/banner/BannerRes.java
+++ b/src/main/java/com/appcenter/BJJ/domain/banner/BannerRes.java
@@ -1,0 +1,14 @@
+package com.appcenter.BJJ.domain.banner;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class BannerRes {
+    @Schema(description = "배너 이미지 이름", example = "092a97a2-19d9-4c67-b1a2-762e612425d0.png")
+    private String imageName;
+    @Schema(description = "배너 페이지 URI", example = "/view/reviews/best?period=DAY")
+    private String pageUri;
+}

--- a/src/main/java/com/appcenter/BJJ/domain/banner/BannerService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/banner/BannerService.java
@@ -1,0 +1,25 @@
+package com.appcenter.BJJ.domain.banner;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BannerService {
+
+    private final BannerRepository bannerRepository;
+
+    public List<BannerRes> findVisibleBanners() {
+        return bannerRepository.findAllBySortOrderIsNotNullOrderBySortOrder()
+                .stream()
+                .map(b -> BannerRes.builder()
+                        .pageUri(b.getPageUri())
+                        .imageName(b.getImageName())
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/global/config/WebMvcConfig.java
+++ b/src/main/java/com/appcenter/BJJ/global/config/WebMvcConfig.java
@@ -17,6 +17,9 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Value("${storage.images.cafeteria}")
     private String CAFETERIA_IMG_DIR;
 
+    @Value("${storage.images.banner")
+    private String BANNER_IMG_DIR;
+
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/images/review/**")
@@ -25,5 +28,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .addResourceLocations("file:///" + ITEM_IMG_DIR);
         registry.addResourceHandler("/images/cafeteria/**")
                 .addResourceLocations("file:///" + CAFETERIA_IMG_DIR);
+        registry.addResourceHandler("/images/banner/**")
+                .addResourceLocations("file:///" + BANNER_IMG_DIR);
     }
 }

--- a/src/main/java/com/appcenter/BJJ/global/config/WebMvcConfig.java
+++ b/src/main/java/com/appcenter/BJJ/global/config/WebMvcConfig.java
@@ -17,7 +17,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Value("${storage.images.cafeteria}")
     private String CAFETERIA_IMG_DIR;
 
-    @Value("${storage.images.banner")
+    @Value("${storage.images.banner}")
     private String BANNER_IMG_DIR;
 
     @Override

--- a/src/main/java/com/appcenter/BJJ/global/exception/ErrorCode.java
+++ b/src/main/java/com/appcenter/BJJ/global/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     MENU_PAIR_NOT_FOUND(HttpStatus.NOT_FOUND, "404-7", "해당 메뉴쌍이 존재하지 않습니다."),
     ITEM_TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "404-8", "아이템의 task가 존재하지 않습니다."),
     MEMBER_TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "404-9", "회원의 task가 존재하지 않습니다."),
+    BANNER_NOT_FOUND(HttpStatus.NOT_FOUND, "404-10", "해당 배너가 존재하지 않습니다."),
 
 
     //409 Conflict


### PR DESCRIPTION
### 🔅 이슈번호
close #110 

---

### ⏰ 작업한 내용
- 배너 기능 구현을 위한 Banner 엔티티 추가
- 배너 관리를 위해 배너 추가, 배너 조회, 배너 수정 API 추가
  - 배너는 sortOrder 필드로 정렬되며 0부터 연속된 정수로 구성
  - 노출되지 않는 배너는 sortOrder=null
  - 배너 이동 시 sortOrder의 연속성이 유지되도록 다른 배너의 순서도 자동 조정
- 프론트에서 배너 목록 조회를 위한 API 추가
- 배너 이미지 접근을 위해 정적 리소스 매핑 추가

---

### ⌛️ 스크린샷 (Optional)

<img width="1421" height="2101" alt="image" src="https://github.com/user-attachments/assets/ee925a4a-e384-4945-870b-6a3b7d13b8de" />
<i>배너 저장 API (관리자용)</i>

<img width="1421" height="2229" alt="image" src="https://github.com/user-attachments/assets/63503e10-59e2-49f3-86a1-6b9094f38feb" />
<i>배너 수정 API (관리자용)</i>

<img width="1421" height="1593" alt="image" src="https://github.com/user-attachments/assets/e7a4e274-8327-473a-9d27-6e0ffd870958" />
<i>배너 목록 조회 API (관리자용)</i>

<img width="1421" height="771" alt="image" src="https://github.com/user-attachments/assets/57a22aa0-15cf-4a37-89e5-c98f9a9fbf89" />
<i>배너 목록 조회 API (프론트용)</i>
