### PR TITLE
[Fix/#121] 배너 페이지 화면 스타일 수정

### DIFF
--- a/src/main/resources/static/css/best-review.css
+++ b/src/main/resources/static/css/best-review.css
@@ -34,6 +34,7 @@ html, body {
 
     background: #FBFF01 url('/images/banners/best-review/background.svg') no-repeat top center;
     background-size: auto 100%;
+    min-height: 100vh;
 }
 
 /* ---------------- 페이지 헤더 ---------------- */

--- a/src/main/resources/static/css/welcome-point.css
+++ b/src/main/resources/static/css/welcome-point.css
@@ -2,13 +2,13 @@
 @font-face {
     font-family: 'Pretendard';
     src: url('/fonts/Pretendard-Medium.woff2') format('woff2');
-    font-weight: 600;
+    font-weight: 500;
 }
 
 @font-face {
     font-family: 'Pretendard';
     src: url('/fonts/Pretendard-Bold.woff2') format('woff2');
-    font-weight: 700;
+    font-weight: 600;
 }
 
 :root {
@@ -58,7 +58,7 @@ html, body {
     background: none;
     padding: 0;
     cursor: pointer;
-    width: calc(100% - 87px);
+    width: 73vw;
 }
 
 .page-button button img {
@@ -74,44 +74,46 @@ html, body {
 }
 
 .page-comments {
-    width: 90%;
+    margin: 4.63vw 6.86vw 20.06vw 6.86vw; /* top right bottom left */
     color: #000;
-    margin-top: 15px;
-    margin-bottom: 65px;
 }
 
 .page-comments-title {
-    color: #000;
-    font-size: 20px;
+    font-size: 4.5vw;       /* 15px */
+    line-height: 6.17vw;     /* 20px */
+    letter-spacing: 0.04vw;  /* 0.131px */
     font-style: normal;
     font-weight: 600;
-    letter-spacing: 0.131px;
-    font-family: Pretendard;
-    margin-top: 10px;
-    margin-left: 10px;
+    color: #000;
 }
 
 .page-comments ul {
     list-style: none;
+    margin-top: 2.47vw;      /* 8px */
+    margin-left: 0.31vw;     /* 1px */
+    width: 87.96vw;          /* 285px */
+    padding-left: 0;
 }
 
 .page-comments li {
-    font-size: 14px;
+    position: relative;      /* ::before 기준 */
+    padding-left: 6vw;       /* 점과 글자 간격 확보 */
+    font-size: 3.9vw;       /* 13px */
+    line-height: 5.56vw;     /* 18px */
+    letter-spacing: 0.04vw;  /* 0.131px */
     color: #000;
-    line-height: 1.6;
-    font-family: Pretendard;
-    font-size: 16px;
     font-style: normal;
     font-weight: 500;
-    line-height: 20px;
-    letter-spacing: 0.131px;
-    padding-right: 10px;
+    display: block;          /* flex 제거 */
 }
 
 .page-comments li::before {
     content: '⦁';
     position: absolute;
-    left: 40px;
+    margin-left: 2vw;
+    top: 0;                  /* 첫 줄 기준 */
+    left: 0;                 /* li 왼쪽 끝 */
+    font-size: 90%;
 }
 
 .modal-overlay {

--- a/src/main/resources/static/css/welcome-point.css
+++ b/src/main/resources/static/css/welcome-point.css
@@ -67,7 +67,7 @@ html, body {
 }
 
 .page-line {
-    width: 375px;
+    width: 91vw;
     height: 0.4px;
     background-color: #999;
     margin-top: 34px;

--- a/src/main/resources/static/css/welcome-point.css
+++ b/src/main/resources/static/css/welcome-point.css
@@ -123,7 +123,6 @@ html, body {
     width: 100%;
     height: 100%;
     background-color: rgba(0, 0, 0, 0.5);
-    display: flex;
     justify-content: center;
     align-items: center;
     display: none;

--- a/src/main/resources/templates/banners/best-review.html
+++ b/src/main/resources/templates/banners/best-review.html
@@ -9,25 +9,27 @@
 <body>
 <div class="page-container">
     <div class="page-caption">
-        <img src="/images/banners/best-review/caption.svg"/>
+        <img src="/images/banners/best-review/caption.svg" alt="오늘의 최고 리뷰어 캡션 이미지"/>
     </div>
 
     <div class="reviewer-profile">
         <div class="portrait">
             <img th:if="${review.memberImageName != null}"
                  th:src="@{/images/{img}(img=${review.memberImageName})}"
-                 class="reviewer-image"/>
+                 class="reviewer-image"
+                 alt="리뷰어 프로필 이미지"/>
             <img th:if="${review.memberImageName == null}"
                  src="/images/banners/best-review/icon.svg"
-                 class="reviewer-image"/>
-            <img src="/images/banners/best-review/frame.svg" class="frame"/>
+                 class="reviewer-image"
+                 alt="기본 리뷰어 아이콘"/>
+            <img src="/images/banners/best-review/frame.svg" class="frame" alt="리뷰어 프로필 프레임"/>
         </div>
         <span class="reviewer-nickname" th:text="${review.memberNickname != null ? review.memberNickname : '최고의리뷰어'}"></span>
     </div>
 
     <div class="review-card">
         <div class="review-likes">
-            <img src="/images/banners/best-review/like.svg" class="like-icon"/>
+            <img src="/images/banners/best-review/like.svg" class="like-icon" alt="좋아요 아이콘"/>
             <span th:if="${review.likeCount != null}" th:text="${review.likeCount}"></span>
         </div>
 
@@ -36,7 +38,8 @@
         <div class="review-images" th:if="${review.imageNames != null and !#lists.isEmpty(review.imageNames)}">
             <img th:each="img : ${review.imageNames}"
                  th:src="@{/images/review/{img}(img=${img})}"
-                 th:attr="onclick=|openPopup('${img}')|" />
+                 th:attr="onclick=|openPopup('${img}')|"
+                 th:alt="'리뷰 이미지 ' + ${img}"/>
         </div>
 
         <div class="review-menu-names">
@@ -58,13 +61,13 @@
 
 <div id="popup" class="popup" onclick="closePopup()">
     <div class="popup-content" onclick="event.stopPropagation()">
-        <img class="popup-img" id="popup-img" />
+        <img class="popup-img" id="popup-img" alt="팝업 리뷰 이미지"/>
         <div class="popup-indicator" id="popup-indicator">1 / 1</div>
         <button class="popup-prev" onclick="prevImage(event)">
-            <img src="/images/banners/best-review/prev.svg" alt="&#60;" />
+            <img src="/images/banners/best-review/prev.svg" alt="이전 이미지" />
         </button>
         <button class="popup-next" onclick="nextImage(event)">
-            <img src="/images/banners/best-review/next.svg" alt="&#62;" />
+            <img src="/images/banners/best-review/next.svg" alt="다음 이미지"/>
         </button>
     </div>
 </div>


### PR DESCRIPTION
### 🔅 이슈번호
close #121 

---

### ⏰ 작업한 내용
- 오늘의 최고 리뷰어 페이지에서 배경 최소 높이를 설정하여 화면 빈 공간에 흰색 배경이 뜨는 문제 해결
- 오늘의 최고 리뷰어 html에서 모든 img 태그에 의미있는 alt 속성 추가
- 신규 가입자 웰컴 포인트 페이지에서 화면 가로 길이가 짧은 경우 가로 구분선이 화면 좌우를 침범하는 문제 해결
- 신규 가입자 웰컴 포인트 페이지에서 화면 가로 길이가 짧은 경우 유의사항 글씨 크기 및 여백이 지나치게 커지는 문제 해결
- 신규 가입자 웰컴 포인트 css에서 불필요한 중복 속성 제거

---

### ⌛️ 스크린샷 (Optional)

<img width="344" height="882" alt="image" src="https://github.com/user-attachments/assets/6d3bf820-61f1-4e57-b10f-8dbe8147db27" />
<div><i>오늘의 최고 리뷰어 페이지</i></div>

<img width="706" height="944" alt="image" src="https://github.com/user-attachments/assets/fae8896a-0e35-4350-a88c-86d373858413" />
<div><i>신규 가입자 웰컴 포인트 페이지 (갤럭시 Z Fold 5 - 접은 화면)</i></div>

<img width="737" height="915" alt="image" src="https://github.com/user-attachments/assets/1fad362b-58e7-4c79-9432-00beaecffd4b" />
<div><i>신규 가입자 웰컴 포인트 페이지 (갤럭시 Z Fold 5 - 펼친 화면)</i></div>

<img width="558" height="753" alt="image" src="https://github.com/user-attachments/assets/413b5898-f730-4525-967a-e9046358b993" />
<div><i>신규 가입자 웰컴 포인트 페이지 (iPhone SE)</i></div>