### PR TITLE
[Fix/#123] 웰컴 포인트 지급 시 필요한 토큰을 웹뷰에서 가져올 수 없는 문제 수정

### DIFF
--- a/src/main/java/com/appcenter/BJJ/domain/event/EventController.java
+++ b/src/main/java/com/appcenter/BJJ/domain/event/EventController.java
@@ -6,10 +6,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
@@ -36,7 +34,11 @@ public class EventController {
 
     @Operation(summary = "웰컴포인트 이벤트 뷰 조회")
     @GetMapping("/welcome-point/view")
-    public String welcomePointView() {
+    public String welcomePointView(
+            @RequestHeader(value = "Authorization", required = false) String authorization,
+            Model model) {
+
+        model.addAttribute("accessToken", authorization);
         return "banners/welcome-point";
     }
 }

--- a/src/main/resources/templates/banners/welcome-point.html
+++ b/src/main/resources/templates/banners/welcome-point.html
@@ -44,12 +44,12 @@
     const alertImage = document.getElementById('alertImage');
 
     claimButton.addEventListener('click', () => {
-        const token = localStorage.getItem('accessToken'); // 로그인 시 저장한 JWT
+        const token = /*[[${accessToken}]]*/ ''; // 로그인 시 저장한 JWT
 
         fetch('/api/events/welcome-point', {
             method: 'POST',
             headers: {
-                'Authorization': `Bearer ${token}`,
+                'Authorization': `${token}`,
                 'Content-Type': 'application/json'
             }
         })


### PR DESCRIPTION
### 🔅 이슈번호
close #123 

---

### ⏰ 작업한 내용
- api/events/welcome-point/view에서 토큰 값을 받아 Model에 넘기도록 수정
- welcome-point.html에서 token 가져오는 방식을 localStorage 대신 Thymeleaf model 변수 사용으로 수정
 - Authorization 헤더에서 'Bearer'가 중복되지 않도록 제거

---

### ⌛️ 스크린샷 (Optional)
