### PR TITLE
[Refactor/#125] AuthenticationEntryPoint 및 AccessDeniedHandler 에서 발생하는 예외를 스택 형식으로 log 띄우기

### DIFF
--- a/src/main/java/com/appcenter/BJJ/global/jwt/AccessDeniedHandlerImpl.java
+++ b/src/main/java/com/appcenter/BJJ/global/jwt/AccessDeniedHandlerImpl.java
@@ -23,7 +23,7 @@ public class AccessDeniedHandlerImpl implements AccessDeniedHandler {
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
         // 처리하지 않은 권한 관련 오류들은 모두 이 곳으로 흘러와서 처리됨
-        log.warn("AccessDeniedHandlerImpl.handle() : 해당 회원에게 권한이 없음");
+        log.warn("[로그] 해당 회원에게 권한이 없음", accessDeniedException);
         ErrorCode errorCode = ErrorCode.ERROR_FORBIDDEN;
         response.setStatus(errorCode.getHttpStatus().value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/com/appcenter/BJJ/global/jwt/AuthenticationEntryPointImpl.java
+++ b/src/main/java/com/appcenter/BJJ/global/jwt/AuthenticationEntryPointImpl.java
@@ -24,7 +24,7 @@ public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         // 처리하지 않은 인증 관련 오류들은 모두 이 곳으로 흘러와서 처리됨
-        log.warn("AuthenticationEntryPointImpl.commence() : 회원이 인증되지 않음");
+        log.warn("[로그] 회원이 인증되지 않음", authException);
         ErrorCode errorCode = ErrorCode.ERROR_UNAUTHORIZED;
         response.setStatus(errorCode.getHttpStatus().value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);


### PR DESCRIPTION
### 🔅 이슈번호
close #125 

---

### ⏰ 작업한 내용
- AuthenticationEntryPoint의 로그 수정
- AccessDeniedHandler의 로그 수정

---

### ⌛️ 스크린샷 (Optional)
<img width="1576" height="122" alt="image" src="https://github.com/user-attachments/assets/9ddc5e56-46cf-44f6-b436-238fc86b0d93" />
<i>로그 예시 (AuthenticationEntryPoint 쪽)</i>
