### PR TITLE
[Feat/#107] 회원 탈퇴 기능 추가

### DIFF
--- a/src/main/java/com/appcenter/BJJ/domain/item/domain/Inventory.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/domain/Inventory.java
@@ -41,7 +41,7 @@ public class Inventory {
         this.expiresAt = expiresAt;
     }
 
-    public static Inventory createDefault(Long memberId, ItemType itemType){
+    public static Inventory createDefault(Long memberId, ItemType itemType) {
         return Inventory.builder()
                 .memberId(memberId)
                 .itemIdx(0)

--- a/src/main/java/com/appcenter/BJJ/domain/item/repository/InventoryRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/repository/InventoryRepository.java
@@ -61,4 +61,6 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
     @Modifying
     @Transactional
     void deleteByMemberIdAndItemIdxAndItemType(Long memberId, Integer itemIdx, ItemType itemType);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/appcenter/BJJ/domain/item/service/InventoryService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/item/service/InventoryService.java
@@ -38,4 +38,9 @@ public class InventoryService {
         //설정한 아이템 착용 활성화
         inventory.toggleIsWearing();
     }
+
+    @Transactional
+    public void delete(Long memberId) {
+        inventoryRepository.deleteAllByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/member/MemberService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/MemberService.java
@@ -9,6 +9,7 @@ import com.appcenter.BJJ.domain.member.enums.MemberRole;
 import com.appcenter.BJJ.domain.member.enums.MemberStatus;
 import com.appcenter.BJJ.domain.member.enums.MemberTaskType;
 import com.appcenter.BJJ.domain.member.enums.SocialProvider;
+import com.appcenter.BJJ.domain.member.schedule.MemberTaskHandler;
 import com.appcenter.BJJ.domain.member.schedule.MemberTaskService;
 import com.appcenter.BJJ.global.exception.CustomException;
 import com.appcenter.BJJ.global.exception.ErrorCode;
@@ -33,11 +34,20 @@ public class MemberService {
     private final JwtProvider jwtProvider;
     private final InventoryRepository inventoryRepository;
     private final MemberTaskService memberTaskService;
+    private final MemberTaskHandler memberTaskHandler;
 
+    @Transactional
     public String socialLogin(SocialLoginReq socialLoginReq) {
         Member member = memberRepository.findByProviderAndProviderId(socialLoginReq.getProvider(), socialLoginReq.getProviderId()).orElseThrow(
                 () -> new CustomException(ErrorCode.USER_NOT_FOUND) // 새로운 회원 => 프론트에게 404를 보내고 회원가입 유도
         );
+
+        LocalDateTime now = LocalDateTime.now();
+        if (member.getMemberStatus() == MemberStatus.DELETE && memberTaskHandler.isWithinDeletePeriod(member.getId(), now)) {
+            // 탈퇴 유예 기간 내 재가입 시 기존 탈퇴를 무효화하고 재가입을 허용
+            member.updateMemberStatus(MemberStatus.ACTIVE);
+            memberTaskHandler.deleteTask(member.getId(), MemberTaskType.DELETE);
+        }
 
         return this.getToken(member.getProviderId());
     }

--- a/src/main/java/com/appcenter/BJJ/domain/member/MemberService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/MemberService.java
@@ -3,14 +3,13 @@ package com.appcenter.BJJ.domain.member;
 import com.appcenter.BJJ.domain.item.domain.Inventory;
 import com.appcenter.BJJ.domain.item.enums.ItemType;
 import com.appcenter.BJJ.domain.item.repository.InventoryRepository;
-import com.appcenter.BJJ.domain.item.service.InventoryService;
 import com.appcenter.BJJ.domain.member.domain.Member;
 import com.appcenter.BJJ.domain.member.dto.*;
 import com.appcenter.BJJ.domain.member.enums.MemberRole;
 import com.appcenter.BJJ.domain.member.enums.MemberStatus;
+import com.appcenter.BJJ.domain.member.enums.MemberTaskType;
 import com.appcenter.BJJ.domain.member.enums.SocialProvider;
-import com.appcenter.BJJ.domain.notification.service.DeviceTokenService;
-import com.appcenter.BJJ.domain.review.service.ReviewService;
+import com.appcenter.BJJ.domain.member.schedule.MemberTaskService;
 import com.appcenter.BJJ.global.exception.CustomException;
 import com.appcenter.BJJ.global.exception.ErrorCode;
 import com.appcenter.BJJ.global.jwt.JwtProvider;
@@ -22,6 +21,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Slf4j
 @Service
 @Transactional(readOnly = true)
@@ -30,10 +31,8 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final AuthenticationManager authenticationManager;
     private final JwtProvider jwtProvider;
-    private final InventoryService inventoryService;
     private final InventoryRepository inventoryRepository;
-    private final ReviewService reviewService;
-    private final DeviceTokenService deviceTokenService;
+    private final MemberTaskService memberTaskService;
 
     public String socialLogin(SocialLoginReq socialLoginReq) {
         Member member = memberRepository.findByProviderAndProviderId(socialLoginReq.getProvider(), socialLoginReq.getProviderId()).orElseThrow(
@@ -77,14 +76,10 @@ public class MemberService {
                 () -> new CustomException(ErrorCode.USER_NOT_FOUND)
         );
 
-        //회원과 관련된 도메인 삭제
-        //리뷰 작성 : 소프트 삭제 / 리뷰 신고, 리뷰 좋아요, 이벤트 : 남기기 (수집용) / 인벤토리, 알림 : 하드 삭제
-        reviewService.deleteByMemberId(memberId);
-        inventoryService.delete((memberId));
-        deviceTokenService.delete(memberId);
-
         //회원 상태를 탈퇴 상태로 변경
+        LocalDateTime now = LocalDateTime.now();
         member.updateMemberStatus(MemberStatus.DELETE);
+        memberTaskService.addOrUpdateTask(member.getId(), now, now.plusMonths(1), MemberTaskType.DELETE);
     }
 
     private String getToken(String providerId) {

--- a/src/main/java/com/appcenter/BJJ/domain/member/MemberService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/MemberService.java
@@ -3,10 +3,14 @@ package com.appcenter.BJJ.domain.member;
 import com.appcenter.BJJ.domain.item.domain.Inventory;
 import com.appcenter.BJJ.domain.item.enums.ItemType;
 import com.appcenter.BJJ.domain.item.repository.InventoryRepository;
+import com.appcenter.BJJ.domain.item.service.InventoryService;
 import com.appcenter.BJJ.domain.member.domain.Member;
 import com.appcenter.BJJ.domain.member.dto.*;
 import com.appcenter.BJJ.domain.member.enums.MemberRole;
+import com.appcenter.BJJ.domain.member.enums.MemberStatus;
 import com.appcenter.BJJ.domain.member.enums.SocialProvider;
+import com.appcenter.BJJ.domain.notification.service.DeviceTokenService;
+import com.appcenter.BJJ.domain.review.service.ReviewService;
 import com.appcenter.BJJ.global.exception.CustomException;
 import com.appcenter.BJJ.global.exception.ErrorCode;
 import com.appcenter.BJJ.global.jwt.JwtProvider;
@@ -26,7 +30,10 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final AuthenticationManager authenticationManager;
     private final JwtProvider jwtProvider;
+    private final InventoryService inventoryService;
     private final InventoryRepository inventoryRepository;
+    private final ReviewService reviewService;
+    private final DeviceTokenService deviceTokenService;
 
     public String socialLogin(SocialLoginReq socialLoginReq) {
         Member member = memberRepository.findByProviderAndProviderId(socialLoginReq.getProvider(), socialLoginReq.getProviderId()).orElseThrow(
@@ -63,14 +70,21 @@ public class MemberService {
                 .build();
     }
 
+    //Soft Delete
     @Transactional
     public void deleteMember(Long memberId) {
-        //TODO 이후 member 관련된 내용도 다같이 지우기
-        if (!memberRepository.existsById(memberId)) {
-            throw new CustomException(ErrorCode.USER_NOT_FOUND);
-        }
-        memberRepository.deleteById(memberId);
-        log.info("MemberService.deleteMember() - 회원 탈퇴 성공");
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        //회원과 관련된 도메인 삭제
+        //리뷰 작성 : 소프트 삭제 / 리뷰 신고, 리뷰 좋아요, 이벤트 : 남기기 (수집용) / 인벤토리, 알림 : 하드 삭제
+        reviewService.deleteByMemberId(memberId);
+        inventoryService.delete((memberId));
+        deviceTokenService.delete(memberId);
+
+        //회원 상태를 탈퇴 상태로 변경
+        member.updateMemberStatus(MemberStatus.DELETE);
     }
 
     private String getToken(String providerId) {

--- a/src/main/java/com/appcenter/BJJ/domain/member/domain/Member.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/domain/Member.java
@@ -80,7 +80,6 @@ public class Member {
         this.isNotificationEnabled = !this.isNotificationEnabled;
     }
 
-    //TODO test용이기에 이후에 없애기
     public void updateMemberStatus(MemberStatus memberStatus) {
         this.memberStatus = memberStatus;
     }

--- a/src/main/java/com/appcenter/BJJ/domain/member/enums/MemberStatus.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/enums/MemberStatus.java
@@ -23,6 +23,13 @@ public enum MemberStatus {
             //밴 상태
             throw new CustomException(ErrorCode.MEMBER_BANNED);
         }
+
+    }, DELETE {
+        @Override
+        public void valid() {
+            //탈퇴 상태
+            throw new CustomException(ErrorCode.MEMBER_DELETE);
+        }
     };
 
     public abstract void valid();

--- a/src/main/java/com/appcenter/BJJ/domain/member/enums/MemberTaskType.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/enums/MemberTaskType.java
@@ -1,0 +1,8 @@
+package com.appcenter.BJJ.domain.member.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum MemberTaskType {
+    SUSPENDED, DELETE
+}

--- a/src/main/java/com/appcenter/BJJ/domain/member/schedule/MemberTask.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/schedule/MemberTask.java
@@ -1,5 +1,6 @@
 package com.appcenter.BJJ.domain.member.schedule;
 
+import com.appcenter.BJJ.domain.member.enums.MemberTaskType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -24,20 +25,25 @@ public class MemberTask {
     @Enumerated(EnumType.STRING)
     private MemberTaskStatus memberTaskStatus;
 
+    @Enumerated(EnumType.STRING)
+    private MemberTaskType memberTaskType;
+
     @Builder
-    private MemberTask(Long memberId, LocalDateTime startAt, LocalDateTime endAt, MemberTaskStatus memberTaskStatus) {
+    private MemberTask(Long memberId, LocalDateTime startAt, LocalDateTime endAt, MemberTaskStatus memberTaskStatus, MemberTaskType memberTaskType) {
         this.memberId = memberId;
         this.startAt = startAt;
         this.endAt = endAt;
         this.memberTaskStatus = memberTaskStatus;
+        this.memberTaskType = memberTaskType;
     }
 
-    public static MemberTask create(Long memberId, LocalDateTime startAt, LocalDateTime endAt) {
+    public static MemberTask create(Long memberId, LocalDateTime startAt, LocalDateTime endAt, MemberTaskType memberTaskType) {
         return MemberTask.builder()
                 .memberId(memberId)
                 .startAt(startAt)
                 .endAt(endAt)
                 .memberTaskStatus(MemberTaskStatus.PENDING)
+                .memberTaskType(memberTaskType)
                 .build();
     }
 
@@ -45,7 +51,7 @@ public class MemberTask {
         this.endAt = endAt;
     }
 
-    public void updateMemberTaskStatue(MemberTaskStatus memberTaskStatus) {
-        this.memberTaskStatus = memberTaskStatus;
+    public void complete() {
+        this.memberTaskStatus = MemberTaskStatus.COMPLETE;
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/member/schedule/MemberTaskHandler.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/schedule/MemberTaskHandler.java
@@ -4,12 +4,15 @@ import com.appcenter.BJJ.domain.item.service.InventoryService;
 import com.appcenter.BJJ.domain.member.MemberRepository;
 import com.appcenter.BJJ.domain.member.domain.Member;
 import com.appcenter.BJJ.domain.member.enums.MemberStatus;
+import com.appcenter.BJJ.domain.member.enums.MemberTaskType;
 import com.appcenter.BJJ.domain.notification.service.DeviceTokenService;
 import com.appcenter.BJJ.global.exception.CustomException;
 import com.appcenter.BJJ.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 /**
  * 회원 관련 스케줄링 작업의 실제 비즈니스 로직을 처리하는 핸들러 클래스
@@ -58,5 +61,16 @@ public class MemberTaskHandler {
         inventoryService.delete((memberId));
         deviceTokenService.delete(memberId);
         memberTaskRepository.deleteAllByMemberId(memberId);
+    }
+
+    public boolean isWithinDeletePeriod(Long memberId, LocalDateTime time) {
+        return memberTaskRepository.findPendingByMemberIdAndMemberTaskType(memberId, MemberTaskType.DELETE)
+                .map(task -> task.getEndAt().isAfter(time))
+                .orElse(false);
+    }
+
+    @Transactional
+    public void deleteTask(Long memberId, MemberTaskType memberTaskType) {
+        memberTaskRepository.deleteByMemberIdAndMemberTaskType(memberId, memberTaskType);
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/member/schedule/MemberTaskHandler.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/schedule/MemberTaskHandler.java
@@ -1,0 +1,62 @@
+package com.appcenter.BJJ.domain.member.schedule;
+
+import com.appcenter.BJJ.domain.item.service.InventoryService;
+import com.appcenter.BJJ.domain.member.MemberRepository;
+import com.appcenter.BJJ.domain.member.domain.Member;
+import com.appcenter.BJJ.domain.member.enums.MemberStatus;
+import com.appcenter.BJJ.domain.notification.service.DeviceTokenService;
+import com.appcenter.BJJ.global.exception.CustomException;
+import com.appcenter.BJJ.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 회원 관련 스케줄링 작업의 실제 비즈니스 로직을 처리하는 핸들러 클래스
+ *
+ * <p>{@link MemberTaskService}의 TaskScheduler에 의해 호출되며,
+ * 트랜잭션이 없는 스케줄러 스레드를 대신하여 각 작업을 트랜잭션 범위 안에서 실행합니다.</p>
+ */
+@Component
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberTaskHandler {
+    private final MemberRepository memberRepository;
+    private final InventoryService inventoryService;
+    private final DeviceTokenService deviceTokenService;
+    private final MemberTaskRepository memberTaskRepository;
+
+    /**
+     * 회원을 활성화 상태로 변경합니다.
+     *
+     * <p>회원 정지 기간이 만료되었을 때 TaskScheduler에 의해 호출됩니다.</p>
+     *
+     * @param memberId 정지 해제할 회원 ID
+     * @throws CustomException 회원을 찾을 수 없는 경우 {@link ErrorCode#USER_NOT_FOUND}
+     */
+    @Transactional
+    public void activateMember(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        member.updateMemberStatus(MemberStatus.ACTIVE);
+    }
+
+    /**
+     * 탈퇴 유예 기간이 만료된 회원의 관련 도메인 데이터를 삭제합니다.
+     *
+     * <p>회원 탈퇴 후 한 달이 경과하였을 때 TaskScheduler에 의해 호출됩니다.</p>
+     *
+     * <ul>
+     *     <li>리뷰, 리뷰 좋아요, 리뷰 신고, 이벤트 : 수집용 데이터로써 유지</li>
+     *     <li>인벤토리, 디바이스 토큰, 회원의 스케줄링 Task : 하드 삭제</li>
+     * </ul>
+     *
+     * @param memberId 데이터를 삭제할 회원 ID
+     */
+    @Transactional
+    public void executeMemberDeletion(Long memberId) {
+        inventoryService.delete((memberId));
+        deviceTokenService.delete(memberId);
+        memberTaskRepository.deleteAllByMemberId(memberId);
+    }
+}

--- a/src/main/java/com/appcenter/BJJ/domain/member/schedule/MemberTaskRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/schedule/MemberTaskRepository.java
@@ -1,5 +1,6 @@
 package com.appcenter.BJJ.domain.member.schedule;
 
+import com.appcenter.BJJ.domain.member.enums.MemberTaskType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -9,10 +10,12 @@ import java.util.Optional;
 public interface MemberTaskRepository extends JpaRepository<MemberTask, Long> {
     List<MemberTask> findAllByMemberTaskStatus(MemberTaskStatus memberTaskStatus);
 
-    @Query("SELECT m FROM MemberTask m WHERE m.memberTaskStatus = 'PENDING'")
-    Optional<MemberTask> findPendingByMemberId(Long memberId);
+    @Query("SELECT m FROM MemberTask m WHERE m.memberTaskStatus = 'PENDING' AND m.id = :memberId AND m.memberTaskType = :memberTaskType")
+    Optional<MemberTask> findPendingByMemberIdAndMemberTaskType(Long memberId, MemberTaskType memberTaskType);
 
 
     @Query("SELECT COUNT(m) FROM MemberTask m WHERE m.memberId = :memberId AND m.memberTaskStatus = 'COMPLETE'")
     Long countByMemberId(Long memberId);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/appcenter/BJJ/domain/member/schedule/MemberTaskRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/schedule/MemberTaskRepository.java
@@ -2,7 +2,9 @@ package com.appcenter.BJJ.domain.member.schedule;
 
 import com.appcenter.BJJ.domain.member.enums.MemberTaskType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,7 +12,7 @@ import java.util.Optional;
 public interface MemberTaskRepository extends JpaRepository<MemberTask, Long> {
     List<MemberTask> findAllByMemberTaskStatus(MemberTaskStatus memberTaskStatus);
 
-    @Query("SELECT m FROM MemberTask m WHERE m.memberTaskStatus = 'PENDING' AND m.id = :memberId AND m.memberTaskType = :memberTaskType")
+    @Query("SELECT m FROM MemberTask m WHERE m.memberTaskStatus = 'PENDING' AND m.memberId = :memberId AND m.memberTaskType = :memberTaskType")
     Optional<MemberTask> findPendingByMemberIdAndMemberTaskType(Long memberId, MemberTaskType memberTaskType);
 
 
@@ -18,4 +20,9 @@ public interface MemberTaskRepository extends JpaRepository<MemberTask, Long> {
     Long countByMemberId(Long memberId);
 
     void deleteAllByMemberId(Long memberId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM MemberTask m WHERE m.memberTaskStatus = 'PENDING' AND m.memberId = :memberId AND m.memberTaskType = :memberTaskType")
+    void deleteByMemberIdAndMemberTaskType(Long memberId, MemberTaskType memberTaskType);
 }

--- a/src/main/java/com/appcenter/BJJ/domain/member/schedule/MemberTaskService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/member/schedule/MemberTaskService.java
@@ -1,10 +1,6 @@
 package com.appcenter.BJJ.domain.member.schedule;
 
-import com.appcenter.BJJ.domain.member.MemberRepository;
-import com.appcenter.BJJ.domain.member.domain.Member;
-import com.appcenter.BJJ.domain.member.enums.MemberStatus;
-import com.appcenter.BJJ.global.exception.CustomException;
-import com.appcenter.BJJ.global.exception.ErrorCode;
+import com.appcenter.BJJ.domain.member.enums.MemberTaskType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -17,16 +13,25 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 
+
+/**
+ * 회원의 상태 변경을 예약/실행/관리하는 스케줄링 클래스
+ */
 @Service
 @RequiredArgsConstructor
 public class MemberTaskService {
     @Qualifier("taskScheduler")
     private final TaskScheduler taskScheduler;
     private final MemberTaskRepository memberTaskRepository;
-    private final MemberRepository memberRepository;
-
+    private final MemberTaskHandler memberTaskHandler;
     public static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
 
+    /**
+     * 애플리케이션 시작 시 DB에 저장된 PENDING 상태의 회원 작업을 조회하여 TaskScheduler에 다시 등록합니다.
+     *
+     * <p>{@link TaskScheduler}는 메모리 기반으로 동작하기 때문에 서버 재시작 시 기존 스케줄이 모두 사라집니다.
+     * 이를 보완하기 위해 미완료 작업을 DB에서 조회하여 재스케줄링합니다.</p>
+     */
     @EventListener(ApplicationReadyEvent.class)
     public void initTask() {
         List<MemberTask> memberTasks = memberTaskRepository.findAllByMemberTaskStatus(MemberTaskStatus.PENDING);
@@ -40,9 +45,9 @@ public class MemberTaskService {
         }
     }
 
-    public void addOrUpdateTask(Long memberId, LocalDateTime startAt, LocalDateTime endAt) {
-        MemberTask memberTask = memberTaskRepository.findPendingByMemberId(memberId).orElseGet(
-                () -> MemberTask.create(memberId, startAt, endAt)
+    public void addOrUpdateTask(Long memberId, LocalDateTime startAt, LocalDateTime endAt, MemberTaskType memberTaskType) {
+        MemberTask memberTask = memberTaskRepository.findPendingByMemberIdAndMemberTaskType(memberId, memberTaskType).orElseGet(
+                () -> MemberTask.create(memberId, startAt, endAt, memberTaskType)
         );
         //원래 있던 것은 endAt만 update 해주면 됨
         memberTask.updateEndAt(endAt);
@@ -52,16 +57,31 @@ public class MemberTaskService {
         memberTaskRepository.save(memberTask);
     }
 
-    private Runnable getTask(MemberTask memberTask) {
-        return () -> { // 회원 정지 풀어주기
-            memberTask.updateMemberTaskStatue(MemberTaskStatus.COMPLETE);
-            memberTaskRepository.save(memberTask);
 
-            Member member = memberRepository.findById(memberTask.getMemberId()).orElseThrow(
-                    () -> new CustomException(ErrorCode.USER_NOT_FOUND)
-            );
-            member.updateMemberStatus(MemberStatus.ACTIVE); //회원 활성화
-            memberRepository.save(member);
+    /**
+     * 회원 작업 타입에 따라 실행할 Runnable을 생성합니다.
+     *
+     * <p>정지 해제 또는 회원 탈퇴와 같은 작업을 수행하며,
+     * 작업 완료 후 MemberTask 상태를 COMPLETE로 변경합니다.</p>
+     *
+     * <p>TaskScheduler에서 실행되는 Runnable은 Spring의 트랜잭션(@Transactional) 적용 대상이 아니므로,
+     * 엔티티 변경 시 변경 감지(Dirty Checking)가 동작하지 않습니다.
+     * 따라서 데이터 변경 사항을 반영하기 위해 Repository의 save()를 직접 호출합니다.</p>
+     */
+    private Runnable getTask(MemberTask memberTask) {
+        return () -> {
+            switch (memberTask.getMemberTaskType()) {
+                case SUSPENDED -> {
+                    // 회원 정지 풀어주기
+                    memberTaskHandler.activateMember(memberTask.getMemberId());
+                    memberTask.complete();
+                    memberTaskRepository.save(memberTask);
+                }
+                case DELETE -> {
+                    // 회원의 탈퇴 작업 진행
+                    memberTaskHandler.executeMemberDeletion(memberTask.getMemberId());
+                }
+            }
         };
     }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/notification/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/repository/DeviceTokenRepository.java
@@ -24,4 +24,6 @@ public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> 
     List<MemberDeviceTokenDto> findActiveTokensInMemberIds(List<Long> memberIds);
 
     List<DeviceToken> findAllByTokenIn(Collection<String> tokens);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/appcenter/BJJ/domain/notification/service/DeviceTokenService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/notification/service/DeviceTokenService.java
@@ -59,4 +59,9 @@ public class DeviceTokenService {
         LocalDateTime now = LocalDateTime.now();
         tokens.forEach(token -> token.updateLastUsedAt(now));
     }
+
+    @Transactional
+    public void delete(Long memeberId) {
+        deviceTokenRepository.deleteAllByMemberId(memeberId);
+    }
 }

--- a/src/main/java/com/appcenter/BJJ/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/repository/ReviewRepository.java
@@ -172,4 +172,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
         WHERE iv.memberId IN :memberIds AND iv.isWearing = true
     """)
     List<MemberCharacterImageDto> findMemberCharacterImages(List<Long> memberIds);
+
+    List<Review> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/appcenter/BJJ/domain/review/service/ReviewReportService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/service/ReviewReportService.java
@@ -3,6 +3,7 @@ package com.appcenter.BJJ.domain.review.service;
 import com.appcenter.BJJ.domain.member.MemberRepository;
 import com.appcenter.BJJ.domain.member.domain.Member;
 import com.appcenter.BJJ.domain.member.enums.MemberStatus;
+import com.appcenter.BJJ.domain.member.enums.MemberTaskType;
 import com.appcenter.BJJ.domain.member.schedule.MemberTaskRepository;
 import com.appcenter.BJJ.domain.member.schedule.MemberTaskService;
 import com.appcenter.BJJ.domain.review.domain.ReviewReport;
@@ -65,7 +66,7 @@ public class ReviewReportService {
                 () -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         //회원 밴 체크 (COMPLETE인 MemberTask가 3개 이상이면 밴 대상)
-        if(memberTaskRepository.countByMemberId(member.getId()) >= BAN_COUNT) {
+        if (memberTaskRepository.countByMemberId(member.getId()) >= BAN_COUNT) {
             member.updateMemberStatus(MemberStatus.BAN);
             return;
         }
@@ -74,7 +75,7 @@ public class ReviewReportService {
         if (reviewReportRepository.countReviewReportByReviewId(reviewId) >= REPORT_COUNT) {
             LocalDateTime now = LocalDateTime.now();
             member.updateMemberStatus(MemberStatus.SUSPENDED);
-            memberTaskService.addOrUpdateTask(member.getId(), now, now.plusDays(7));
+            memberTaskService.addOrUpdateTask(member.getId(), now, now.plusDays(7), MemberTaskType.SUSPENDED);
 
             delete(reviewId); //리뷰 신고 내역 soft delete
             reviewService.delete(reviewId); // 누적 신고 당한 리뷰 삭제

--- a/src/main/java/com/appcenter/BJJ/domain/review/service/ReviewReportService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/service/ReviewReportService.java
@@ -76,7 +76,7 @@ public class ReviewReportService {
             member.updateMemberStatus(MemberStatus.SUSPENDED);
             memberTaskService.addOrUpdateTask(member.getId(), now, now.plusDays(7));
 
-            delete(reviewId); //리뷰 신고 내역 sofe delete
+            delete(reviewId); //리뷰 신고 내역 soft delete
             reviewService.delete(reviewId); // 누적 신고 당한 리뷰 삭제
         }
     }

--- a/src/main/java/com/appcenter/BJJ/domain/review/service/ReviewService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/service/ReviewService.java
@@ -208,6 +208,11 @@ public class ReviewService {
         return menuPairId;
     }
 
+    @Transactional
+    public void deleteByMemberId(Long memberId) {
+        reviewRepository.findAllByMemberId(memberId).forEach(Review::deleteReview);
+    }
+
     public ReviewImagesPagedRes findReviewImagesByMenuPairId(Long menuPairId, int pageNumber, int pageSize) {
         log.info("[로그] findReviewImagesByMenuPairId(), menuPairId : {}, pageNumber : {}, pageSize: {}", menuPairId, pageNumber, pageSize);
 

--- a/src/main/java/com/appcenter/BJJ/domain/review/service/ReviewService.java
+++ b/src/main/java/com/appcenter/BJJ/domain/review/service/ReviewService.java
@@ -5,6 +5,7 @@ import com.appcenter.BJJ.domain.image.ImageRepository;
 import com.appcenter.BJJ.domain.member.MemberRepository;
 import com.appcenter.BJJ.domain.member.domain.Member;
 import com.appcenter.BJJ.domain.member.enums.MemberStatus;
+import com.appcenter.BJJ.domain.member.enums.MemberTaskType;
 import com.appcenter.BJJ.domain.member.schedule.MemberTask;
 import com.appcenter.BJJ.domain.member.schedule.MemberTaskRepository;
 import com.appcenter.BJJ.domain.menu.domain.MenuPair;
@@ -61,7 +62,7 @@ public class ReviewService {
 
         //정지 당한 회원의 리뷰 작성 제재
         if (memberRepository.existsByIdAndMemberStatus(memberId, MemberStatus.SUSPENDED)) {
-            MemberTask memberTask = memberTaskRepository.findPendingByMemberId(memberId).orElseThrow(
+            MemberTask memberTask = memberTaskRepository.findPendingByMemberIdAndMemberTaskType(memberId, MemberTaskType.SUSPENDED).orElseThrow(
                     () -> new CustomException(ErrorCode.MEMBER_TASK_NOT_FOUND)
             );
             throw new ReviewSuspensionException(memberTask.getStartAt(), memberTask.getEndAt());

--- a/src/main/java/com/appcenter/BJJ/global/exception/ErrorCode.java
+++ b/src/main/java/com/appcenter/BJJ/global/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     ERROR_FORBIDDEN(HttpStatus.FORBIDDEN, "403-1", "이 리소스에 접근할 권한이 없습니다."),
     MEMBER_SUSPENDED_FOR_REVIEW(HttpStatus.FORBIDDEN, "403-2", "리뷰 작성이 제한된 사용자입니다."),
     MEMBER_BANNED(HttpStatus.FORBIDDEN, "403-3", "해당 회원은 밴 처리되었습니다."),
+    MEMBER_DELETE(HttpStatus.FORBIDDEN, "403-4", "해당 회원은 탈퇴 처리되었습니다."),
 
     //404 Not Found
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "404-1", "해당 회원이 존재하지 않습니다."),


### PR DESCRIPTION
### 🔅 이슈번호
close #107 

---

### ⏰ 작업한 내용
- 회원 탈퇴 기능 추가
- 회원과 관련된 정보 (리뷰, 아이템, 알림 등) 들을 삭제 처리
- 정보 수집에 관한 데이터들은 유지 / 수집이 필요 없는 데이터는 soft 또는 hard delete 로 처리
- 탈퇴한 회원 접근 시 예외 발생하도록 설정

---

### ⌛️ 스크린샷 (Optional)
<img width="700" height="492" alt="image" src="https://github.com/user-attachments/assets/070c4f7c-de5d-4c05-b164-4942670f0830" />
<i>회원 탈퇴 API</i>
